### PR TITLE
fix: resolve UnicodeEncodeError on Windows with cp1252 console

### DIFF
--- a/src/ralphify/cli.py
+++ b/src/ralphify/cli.py
@@ -5,7 +5,10 @@ from pathlib import Path
 from typing import Optional
 
 import typer
-from rich import print as rprint
+from rich.console import Console
+
+_console = Console(highlight=False)
+rprint = _console.print
 
 from ralphify.detector import detect_project
 


### PR DESCRIPTION
## Summary

- Fix `UnicodeEncodeError` crash on Windows when printing the ASCII art banner

## Root Cause

`from rich import print as rprint` uses Rich's legacy Windows console renderer on systems with cp1252 encoding. The `BANNER` string contains Unicode block characters (`█`) that cp1252 cannot encode, causing a crash in `rich._win32_console.write_text`.

## Fix

Replace the `rich.print` import with an explicit `Console` instance:

```python
from rich.console import Console

_console = Console(highlight=False)
rprint = _console.print
```

`Console()` auto-detects the terminal properly and avoids the legacy Windows code path. `highlight=False` preserves existing behavior where only explicit Rich markup is used. All existing `rprint` calls continue to work unchanged.

## Test plan

- [x] All 24 existing tests pass (`uv run pytest tests/ -v`)
- [x] No changes to CLI behavior, output formatting, or test expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)