### PR TITLE
Fix Unicode crash on Windows

### DIFF
--- a/src/ralphify/cli.py
+++ b/src/ralphify/cli.py
@@ -24,6 +24,10 @@ from ralphify.contexts import discover_contexts, run_all_contexts, resolve_conte
 from ralphify.instructions import discover_instructions, resolve_instructions
 from ralphify.detector import detect_project
 
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8")
+    sys.stderr.reconfigure(encoding="utf-8")
+
 _console = Console(highlight=False)
 rprint = _console.print
 


### PR DESCRIPTION
## Summary
- On Windows, `sys.stdout` defaults to cp1252 encoding which cannot represent the Unicode banner characters, crashing all CLI commands
- Reconfigure stdout/stderr to UTF-8 at startup on Windows

## Test plan
- [x] `ralph init` works on Windows
- [x] `ralph run` works on Windows
- [x] All 197 tests pass