### PR TITLE
Fix agent command resolution on Windows

### DIFF
--- a/src/ralphify/engine.py
+++ b/src/ralphify/engine.py
@@ -10,6 +10,7 @@ The loop: run commands → assemble prompt → pipe to agent → repeat.
 from __future__ import annotations
 
 import shlex
+import shutil
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
@@ -178,6 +179,14 @@ def _run_agent_phase(
         raise ValueError(
             f"Invalid agent command syntax: {config.agent!r}. {_field_hint(FIELD_AGENT)}"
         ) from exc
+
+    # Resolve the executable via PATH so that bare names like "claude" work
+    # on Windows, where subprocess.Popen requires the full filename (e.g.
+    # "claude.exe") unless shell=True.
+    if cmd:
+        resolved = shutil.which(cmd[0])
+        if resolved is not None:
+            cmd[0] = resolved
 
     # Option C: recheck per-line so mid-iteration peek toggle takes effect.
     # When neither peek nor logging needs output, pass None so the blocking


### PR DESCRIPTION
## Summary

- On Windows, `subprocess.Popen` cannot find executables by bare name (e.g. `claude`) without the file extension (`.exe`). This causes `ralph run` to crash with `FileNotFoundError` when the `agent` field in RALPH.md uses a bare command name like `claude -p --dangerously-skip-permissions`.
- Uses `shutil.which()` to resolve the executable path before passing it to `subprocess.Popen`. This works cross-platform — finding `claude` on Unix and `claude.exe` on Windows.
- No behavior change on macOS/Linux where bare names already resolve correctly.

## Reproduction

On Windows with Claude Code installed:
```yaml
# RALPH.md frontmatter
agent: claude -p --dangerously-skip-permissions
```

```
$ ralph run .
Run crashed: Agent command not found: 'claude -p --dangerously-skip-permissions'
FileNotFoundError: [WinError 2] The system cannot find the file specified
```

## Fix

Added `shutil.which()` resolution in `_run_agent_phase()` (engine.py) right after `shlex.split()` parses the agent command string. If the executable is found on PATH, the resolved absolute path replaces the bare name. If not found, the original value is preserved so the existing `FileNotFoundError` handling still produces a clear error message.

## Test plan

- [x] Verified fix resolves the crash on Windows 11
- [ ] Confirm no regression on macOS/Linux (bare names still work)
- [ ] Existing tests pass (`test_engine.py` agent-related tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)