### PR TITLE
feat(adapters): surface prompt-cache usage via extract_cache_stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Ralph loops give you:
 | **grow-coverage** | Write tests for untested modules, one per iteration, until coverage hits the target |
 | **security-audit** | Hunt for vulnerabilities — scan, find, fix, verify, repeat |
 | **clear-backlog** | Work through a TODO list or issue tracker, one task per loop |
+| **promise-completion** | Work until a target is done, then emit a promise tag so the loop stops early |
 | **write-docs** | Generate documentation for undocumented modules, one at a time |
 | **improve-codebase** | Find and fix code smells, refactor patterns, modernize APIs |
 | **migrate** | Incrementally migrate files from one framework or pattern to another |
@@ -95,11 +96,17 @@ Scaffold a ralph and start experimenting:
 ralph scaffold my-ralph
 ```
 
+The scaffolded `RALPH.md` includes the normal command/arg template plus a commented promise-completion path you can enable if the agent should stop early by emitting a matching `<promise>...</promise>` tag.
+
+For a committed example, see [`examples/promise-completion/RALPH.md`](examples/promise-completion/RALPH.md) — it shows a loop that exits early once the requested target is complete.
+
 Edit `my-ralph/RALPH.md`, then run it:
 
 ```bash
 ralph run my-ralph           # loops until Ctrl+C
 ralph run my-ralph -n 5      # run 5 iterations then stop
+# from a repo checkout:
+ralph run examples/promise-completion -n 10 --target "stabilize the failing auth tests"
 ```
 
 ### What `ralph run` does

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -36,9 +36,34 @@ Your agent must:
 
 1. **Read a prompt from stdin** — the full assembled prompt is piped in
 2. **Do work in the current directory** — edit files, run commands, make commits
-3. **Exit when done** — exit code 0 means success, non-zero means failure
+3. **Exit cleanly** — exit code `0` means the agent process succeeded; non-zero means failure
+4. **Optionally emit a completion signal** — set `completion_signal` in frontmatter (default inner text: `RALPH_PROMISE_COMPLETE`) if you want the agent to print an explicit `<promise>...</promise>` marker
 
-That's it. No special protocol, no API — just stdin in, work done, process exits.
+Normal exit codes still indicate process success or failure. They do **not** trigger promise completion by themselves.
+
+Ralphify only stops early on promise completion when both of these are true:
+
+- `stop_on_completion_signal: true`
+- the matching `<promise>...</promise>` tag is detected in agent output or captured result text
+
+`completion_signal` is the inner promise text. For example, `completion_signal: COMPLETE` means the agent must output `<promise>COMPLETE</promise>`.
+
+Ralphify still keeps its own command/prompt loop architecture. Only the promise tag format and matching align with Ralph-Wiggum.
+
+Minimal example:
+
+```markdown
+---
+agent: claude -p --dangerously-skip-permissions
+completion_signal: COMPLETE
+stop_on_completion_signal: true
+---
+
+Implement the next todo. When the work is fully complete, print
+<promise>COMPLETE</promise> and exit.
+```
+
+That's it. No API required — just stdin in, output out, process exits.
 
 ## Claude Code
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -113,6 +113,7 @@ The loop also stops automatically when:
 
 - All `-n` iterations have completed
 - `--stop-on-error` is set and the agent exits non-zero or times out
+- `stop_on_completion_signal: true` is set in frontmatter and the matching `<promise>...</promise>` tag is detected in agent output or captured result text
 
 ### Peeking at live agent output
 
@@ -152,7 +153,7 @@ ralph scaffold              # Creates RALPH.md in the current directory
 |---|---|---|
 | `[NAME]` | none | Directory name. If omitted, creates RALPH.md in the current directory |
 
-The generated template includes an example command (`git-log`), an example arg (`focus`), and a prompt body with placeholders for both. Edit it, then run [`ralph run`](#ralph-run). See [Getting Started](getting-started.md) for a full walkthrough.
+The generated template includes an example command (`git-log`), an example arg (`focus`), a prompt body with placeholders for both, and commented `completion_signal` / `stop_on_completion_signal` lines showing the promise-completion path. Uncomment them if you want the agent to stop early by emitting a matching `<promise>...</promise>` tag. Then run [`ralph run`](#ralph-run). See [Getting Started](getting-started.md) for a full walkthrough.
 
 Errors if `RALPH.md` already exists at the target location.
 
@@ -190,6 +191,10 @@ Your instructions here. Reference args with {{ args.dir }}.
 | `commands` | list | no | Commands to run each iteration (each has `name` and `run`) |
 | `args` | list of strings | no | Declared argument names for user arguments. Letters, digits, hyphens, and underscores only. |
 | `credit` | bool | no | Append co-author trailer instruction to prompt (default: `true`) |
+| `completion_signal` | string | no | Inner text for the completion promise tag. `COMPLETE` means the agent must emit `<promise>COMPLETE</promise>` (default inner text: `RALPH_PROMISE_COMPLETE`) |
+| `stop_on_completion_signal` | bool | no | Stop the loop early when the matching `<promise>...</promise>` tag is detected (default: `false`) |
+
+Exit code `0` still only means the agent process succeeded. Ralphify keeps its own loop architecture; only the promise tag format and matching align with Ralph-Wiggum.
 
 ### Commands
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -1,13 +1,13 @@
 ---
 title: Ralph Loop Recipes
-description: Copy-pasteable ralph loop setups for autonomous ML research, test coverage, code migration, security scanning, deep research, documentation, bug fixing, and codebase improvement.
-keywords: ralphify cookbook, autonomous coding recipes, RALPH.md examples, documentation loop, bug fixing loop, codebase improvement, deep research agent, code migration loop, security scanning agent, test coverage automation, autoresearch, autonomous ML research
+description: Copy-pasteable ralph loop setups for autonomous ML research, promise-based early exit, test coverage, code migration, security scanning, deep research, documentation, bug fixing, and codebase improvement.
+keywords: ralphify cookbook, autonomous coding recipes, RALPH.md examples, promise completion, early exit agent loop, documentation loop, bug fixing loop, codebase improvement, deep research agent, code migration loop, security scanning agent, test coverage automation, autoresearch, autonomous ML research
 ---
 
 # Cookbook
 
 !!! tldr "TL;DR"
-    8 copy-pasteable ralph loops: [autoresearch](#autoresearch), [codebase improvement](#codebase-improvement), [documentation](#documentation-loop), [bug hunting](#bug-hunter), [deep research](#deep-research), [code migration](#code-migration), [security scanning](#security-scan), and [test coverage](#test-coverage). Each is a real, runnable example from the `examples/` directory.
+    9 copy-pasteable ralph loops: [autoresearch](#autoresearch), [codebase improvement](#codebase-improvement), [documentation](#documentation-loop), [bug hunting](#bug-hunter), [deep research](#deep-research), [code migration](#code-migration), [security scanning](#security-scan), [test coverage](#test-coverage), and [promise completion](#promise-completion). Each is a real, runnable example from the `examples/` directory.
 
 Copy-pasteable setups for common autonomous workflows. Each recipe is a real, runnable ralph from the [`examples/`](https://github.com/computerlovetech/ralphify/tree/main/examples) directory.
 
@@ -266,6 +266,40 @@ ralph run test-coverage -n 5 --target "focus on error handling paths" --log-dir 
 ```
 
 The coverage report gives the agent a clear metric to improve and shows exactly which lines are missing, so it always knows where to focus.
+
+---
+
+## Stop the loop when the task is complete {: #promise-completion }
+
+A loop that uses ralphify's promise-completion path to stop before the iteration budget. The agent keeps working until the requested target is done, then emits `<promise>COMPLETE</promise>` so the run ends immediately instead of burning the remaining iterations.
+
+**`promise-completion/RALPH.md`**
+
+```markdown
+--8<-- "examples/promise-completion/RALPH.md"
+```
+
+```bash
+ralph run promise-completion -n 10 --target "stabilize the failing auth tests"
+```
+
+```text
+▶ Running: promise-completion
+  3 commands · max 10 iterations
+
+── Iteration 1 ──
+  Commands: 3 ran
+✓ Iteration 1 completed (51.4s)
+
+── Iteration 2 ──
+  Commands: 3 ran
+✓ Iteration 2 completed via promise tag <promise>COMPLETE</promise> (43.2s)
+
+──────────────────────
+Done: 2 iterations — 2 succeeded
+```
+
+Set `completion_signal` to the inner promise text and `stop_on_completion_signal: true` to enable early exit. The agent must emit the matching `<promise>...</promise>` tag — bare text does not count.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -50,9 +50,10 @@ ralph scaffold my-ralph
 ```text
 Created my-ralph/RALPH.md
 Edit the file, then run: ralph run my-ralph
+Optional early exit: uncomment completion_signal + stop_on_completion_signal and emit <promise>COMPLETE</promise>.
 ```
 
-This creates `my-ralph/RALPH.md` with a ready-to-customize template including an example command, arg, and prompt. Edit the task section, [test it](#step-3-do-a-test-run), then follow [Step 4](#step-4-add-a-test-command) to add a test command — test feedback is what makes the loop self-healing.
+This creates `my-ralph/RALPH.md` with a ready-to-customize template including an example command, arg, prompt, and a commented promise-completion example. If you want the loop to stop before its iteration budget, uncomment `completion_signal` and `stop_on_completion_signal`, then tell the agent to emit the matching `<promise>...</promise>` tag when it is done. Edit the task section, [test it](#step-3-do-a-test-run), then follow [Step 4](#step-4-add-a-test-command) to add a test command — test feedback is what makes the loop self-healing.
 
 Or create the file manually as shown below.
 
@@ -251,6 +252,16 @@ The agent's output streams live to your terminal between the iteration markers �
 
 If the agent breaks a test, the next iteration sees the failure output via `{{ commands.tests }}` and fixes it automatically.
 
+!!! tip "Optional: stop when the task is fully complete"
+    Add these frontmatter fields if you want the loop to stop on an explicit completion marker:
+
+    ```yaml
+    completion_signal: COMPLETE
+    stop_on_completion_signal: true
+    ```
+
+    `completion_signal` is the inner promise text. With `completion_signal: COMPLETE`, the agent must emit `<promise>COMPLETE</promise>`. If you omit it, the default promise tag is `<promise>RALPH_PROMISE_COMPLETE</promise>`. The loop only exits early when `stop_on_completion_signal` is enabled and that tag is detected in agent output or captured result text. Exit code `0` still only means the agent process succeeded.
+
 Once you're confident the loop works, drop the `-n 3` to let it run indefinitely. Press `Ctrl+C` to stop.
 
 ## Step 7: Steer while it runs
@@ -274,7 +285,7 @@ Read TODO.md and focus only on the API module.
 This is the most powerful part of ralph loops — you're steering a running agent with a text file.
 
 !!! warning "Frontmatter changes need a restart"
-    Only the **prompt body** is re-read each iteration. Frontmatter fields (`agent`, `commands`, `args`) are parsed once at startup. If you add a new command or change the agent, stop the loop with `Ctrl+C` and restart it.
+    Only the **prompt body** is re-read each iteration. Frontmatter is parsed once at startup. If you add a new command, change the agent, or change completion settings, stop the loop with `Ctrl+C` and restart it.
 
 ## Next steps
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -19,7 +19,7 @@ Every iteration follows the same sequence. Here's what happens at each step.
 
 The prompt body (everything below the frontmatter) is read from disk **every iteration**. This means you can edit the prompt text — add rules, change the task, adjust constraints — while the loop is running. Changes take effect on the next cycle.
 
-Frontmatter fields (`agent`, `commands`, `args`) are parsed once at startup. To change those, restart the loop.
+Frontmatter settings are parsed once at startup. To change them, restart the loop.
 
 ### 2. Run commands and capture output
 
@@ -70,6 +70,8 @@ echo "<assembled prompt>" | claude -p --dangerously-skip-permissions
 
 The agent reads the prompt, does work in the current directory (edits files, runs commands, makes commits), and exits. Ralphify waits for the agent process to finish.
 
+Exit codes still mean process success or failure. Promise completion is separate: `completion_signal` is the inner promise text (default: `RALPH_PROMISE_COMPLETE`), so ralphify only stops early when `stop_on_completion_signal` is `true` and the agent emits the matching `<promise>...</promise>` tag in output or captured result text. This aligns the promise format with Ralph-Wiggum, but ralphify still uses its own command/prompt loop architecture.
+
 When the agent command starts with `claude`, ralphify automatically adds `--output-format stream-json --verbose` to enable structured streaming. This lets ralphify track agent activity in real time — you don't need to configure this yourself.
 
 ### 6. Loop back with fresh context
@@ -82,7 +84,7 @@ The loop starts the next iteration from step 1. The RALPH.md is re-read, command
 |---|---|---|
 | Prompt body | Every iteration | Edit the prompt while the loop runs — the next iteration follows your new instructions |
 | Command output | Every iteration | The agent always sees fresh data (latest git log, current test status, etc.) |
-| Frontmatter (`agent`, `commands`, `args`) | Once at startup | Parsed when the loop starts. Restart to pick up changes. |
+| Frontmatter settings | Once at startup | Parsed when the loop starts. Restart to pick up changes. |
 | User arguments | Once at startup | Passed via CLI flags, constant for the run |
 
 ## How broken code gets fixed automatically
@@ -179,6 +181,7 @@ The loop continues until one of these happens:
 | `Ctrl+C` (first) | Gracefully finishes the current iteration, then stops the loop. The agent completes its work and the iteration result is recorded. |
 | `Ctrl+C` (second) | Force-stops immediately — kills the agent process and exits. Use when you don't want to wait for the current iteration to finish. |
 | `-n` limit reached | Loop stops after completing the specified number of iterations |
+| `stop_on_completion_signal: true` and matching `<promise>...</promise>` tag detected | Loop stops after the current iteration |
 | `--stop-on-error` and agent exits non-zero or times out | Loop stops after the current iteration |
 | `--timeout` exceeded | Agent process is killed, iteration is marked as timed out, loop continues (unless `--stop-on-error`) |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ hide:
 
 A **ralph** is a directory with a `RALPH.md` file — a skill-like format that bundles a prompt, the commands to run between iterations, and any files the agent needs. **Ralphify** is the CLI runtime that executes them.
 
-See [The Ralph Format](blog/posts/the-ralph-format.md) for the full spec.
+See [The Ralph Format](blog/posts/the-ralph-standard.md) for the full spec.
 
 ```
 grow-coverage/
@@ -52,7 +52,7 @@ One directory. One command. Each iteration starts with fresh context and current
 *Works with any agent CLI. Swap `claude -p` for Codex, Aider, or your own — just change the `agent` field.*
 
 [Get Started](getting-started.md){ .md-button .md-button--primary }
-[Read the Format Spec](blog/posts/the-ralph-format.md){ .md-button }
+[Read the Format Spec](blog/posts/the-ralph-standard.md){ .md-button }
 
 ---
 
@@ -149,7 +149,7 @@ Ralphs are to the outer loop what [skills](https://agentskills.io/) are to the i
 
 ## Next steps
 
-- **[The Ralph Format](blog/posts/the-ralph-format.md)** — the full spec
+- **[The Ralph Format](blog/posts/the-ralph-standard.md)** — the full spec
 - **[Getting Started](getting-started.md)** — from install to a running loop in 10 minutes
 - **[How it Works](how-it-works.md)** — what happens inside each iteration
 - **[Cookbook](cookbook.md)** — copy-pasteable ralphs for coding, docs, research, and more

--- a/docs/quick-reference.md
+++ b/docs/quick-reference.md
@@ -78,6 +78,8 @@ Your instructions here. Use {{ args.dir }} for user arguments. <!-- (6) -->
 | `commands` | list | no | Commands to run each iteration |
 | `args` | list | no | User argument names. Letters, digits, hyphens, and underscores only. |
 | `credit` | bool | no | Append co-author trailer instruction to prompt (default: `true`) |
+| `completion_signal` | string | no | Inner text for the completion promise tag. `COMPLETE` means the agent must emit `<promise>COMPLETE</promise>` (default inner text: `RALPH_PROMISE_COMPLETE`) |
+| `stop_on_completion_signal` | bool | no | Stop the loop early when the matching `<promise>...</promise>` tag is detected (default: `false`) |
 
 ### Command fields
 
@@ -160,6 +162,7 @@ Each iteration:
 | `P` (shift+p) | Open full-screen peek — scroll the entire activity buffer. `j/k` line, `space/b` page, `g/G` top/bottom, `q` or `P` exits |
 | `-n` limit reached | Stops after the specified number of iterations |
 | `--stop-on-error` | Stops if agent exits non-zero or times out |
+| matching `<promise>...</promise>` tag detected | Stops early only when `stop_on_completion_signal: true` and the configured promise tag is found in agent output/result |
 
 ## Live editing
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -522,7 +522,7 @@ For programmatic control over concurrent runs, use the [Python API's `RunManager
 
 ### Can I edit RALPH.md while the loop runs?
 
-Yes. The prompt body (everything below the frontmatter) is re-read every iteration — edit the prompt text and changes take effect on the next cycle. Frontmatter fields (`agent`, `commands`, `args`) are parsed once at startup, so changing those requires restarting the loop.
+Yes. The prompt body (everything below the frontmatter) is re-read every iteration — edit the prompt text and changes take effect on the next cycle. Frontmatter settings are parsed once at startup, so changing them requires restarting the loop.
 
 ### How do I disable the co-author credit in commits?
 

--- a/examples/promise-completion/RALPH.md
+++ b/examples/promise-completion/RALPH.md
@@ -1,0 +1,49 @@
+---
+agent: claude -p --dangerously-skip-permissions
+commands:
+  - name: tests
+    run: uv run pytest -x
+  - name: lint
+    run: uv run ruff check .
+  - name: git-log
+    run: git log --oneline -10
+args:
+  - target
+completion_signal: COMPLETE
+stop_on_completion_signal: true
+---
+
+# Stop Early with a Promise Tag
+
+You are an autonomous coding agent running in a loop. Each iteration
+starts with a fresh context. Your progress lives in the code and git.
+
+## Recent commits
+
+{{ commands.git-log }}
+
+## Test results
+
+{{ commands.tests }}
+
+## Lint
+
+{{ commands.lint }}
+
+Fix any failing tests or lint violations above before doing anything else.
+
+## Task
+
+Get the requested target to a clean, shippable state.
+{{ args.target }}
+
+When the task is complete and no more changes are needed, print
+<promise>COMPLETE</promise> and exit so the loop stops early.
+
+## Rules
+
+- One fix or improvement per iteration
+- Keep the target scoped — do not drift into unrelated cleanup
+- If tests or lint are failing, fix them before new work
+- Only emit <promise>COMPLETE</promise> when the target is truly done
+- Commit with a descriptive message and push

--- a/src/ralphify/_agent.py
+++ b/src/ralphify/_agent.py
@@ -37,6 +37,7 @@ from ralphify._output import (
     collect_output,
     warn,
 )
+from ralphify.adapters import CLIAdapter, select_adapter
 
 # ── Callback type aliases ──────────────────────────────────────────────
 # Used across the streaming and blocking execution paths for callbacks
@@ -52,15 +53,6 @@ OutputLineCallback = Callable[[str, OutputStream], None]
 # that only "stdout" / "stderr" ever reach ``on_output_line``.
 _STDOUT: OutputStream = "stdout"
 _STDERR: OutputStream = "stderr"
-
-# Agent binary name that supports --output-format stream-json.
-# Public because _console_emitter also needs this for display logic.
-CLAUDE_BINARY = "claude"
-
-# CLI flags appended when streaming mode is used.
-_OUTPUT_FORMAT_FLAG = "--output-format"
-_STREAM_FORMAT = "stream-json"
-_VERBOSE_FLAG = "--verbose"
 
 # JSON stream event types and fields for result extraction.
 _RESULT_EVENT_TYPE = "result"
@@ -288,19 +280,6 @@ def _write_log(
     return log_file
 
 
-def _supports_stream_json(cmd: list[str]) -> bool:
-    """Return True if the agent command supports ``--output-format stream-json``.
-
-    Currently only Claude Code supports this protocol.  To add streaming
-    support for another agent, extend the check here — no other changes
-    needed since :func:`_run_agent_streaming` handles the protocol generically.
-    """
-    if not cmd:
-        return False
-    binary = Path(cmd[0]).stem
-    return binary == CLAUDE_BINARY
-
-
 def _readline_pump(
     stdout: IO[str],
     line_queue: queue.Queue[str | None],
@@ -444,16 +423,19 @@ def _run_agent_streaming(
 ) -> AgentResult:
     """Run the agent subprocess with line-by-line streaming of JSON output.
 
-    Used for agents that support ``--output-format stream-json`` (e.g. Claude
-    Code).  Stream processing is delegated to :func:`_read_agent_stream`;
-    this function owns the subprocess lifecycle (spawn, stdin delivery,
-    timeout kill, and cleanup via ``try/finally``).
+    Used for adapters whose ``supports_streaming`` flag is True (e.g. Claude
+    Code's ``--output-format stream-json``, Codex's ``--json``).  The command
+    list *must already include* any adapter-required flags —
+    :func:`execute_agent` calls ``adapter.build_command`` before dispatching.
+
+    Stream processing is delegated to :func:`_read_agent_stream`; this
+    function owns the subprocess lifecycle (spawn, stdin delivery, timeout
+    kill, and cleanup via ``try/finally``).
 
     stderr is drained concurrently on a background reader thread so large
     stderr volume can't deadlock the child on a full OS pipe buffer while
     the main thread is reading stdout.
     """
-    stream_cmd = cmd + [_OUTPUT_FORMAT_FLAG, _STREAM_FORMAT, _VERBOSE_FLAG]
     start = time.monotonic()
     deadline = (start + timeout) if timeout is not None else None
 
@@ -466,7 +448,7 @@ def _run_agent_streaming(
     stderr_thread: threading.Thread | None = None
 
     proc = subprocess.Popen(
-        stream_cmd,
+        cmd,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE if pipe_stderr else None,
@@ -764,6 +746,7 @@ def execute_agent(
     timeout: float | None,
     log_dir: Path | None,
     iteration: int,
+    adapter: CLIAdapter | None = None,
     on_activity: ActivityCallback | None = None,
     on_output_line: OutputLineCallback | None = None,
     capture_result_text: bool = False,
@@ -771,22 +754,27 @@ def execute_agent(
 ) -> AgentResult:
     """Run the agent subprocess, auto-selecting streaming or blocking mode.
 
-    Uses streaming mode for agents that support ``--output-format stream-json``
-    (e.g. Claude Code); all other agents use the blocking path that drains
-    stdout and stderr via reader threads.  The *on_activity* callback is
-    only invoked in streaming mode; *on_output_line* fires for both modes
-    as raw lines arrive.
+    The *adapter* argument (or :func:`select_adapter` when omitted) decides
+    which execution path runs: adapters whose ``supports_streaming`` flag is
+    True take the line-streaming path that drives ``on_activity`` callbacks;
+    all others take the blocking path with concurrent stdout/stderr drain.
+    ``adapter.build_command(cmd)`` is applied before spawning, so the CLI
+    receives any flags the adapter requires (e.g. Claude's
+    ``--output-format stream-json --verbose`` or Codex's ``--json``).
 
     This is the single entry point the engine should use — callers don't need
     to know which execution mode is selected.
     """
-    supports_stream_json = _supports_stream_json(cmd)
+    if adapter is None:
+        adapter = select_adapter(cmd)
+    cmd = adapter.build_command(cmd)
+    supports_streaming = adapter.supports_streaming
     if capture_stdout is None:
         capture_stdout = log_dir is not None or (
-            not supports_stream_json and on_output_line is None and capture_result_text
+            not supports_streaming and on_output_line is None and capture_result_text
         )
 
-    if supports_stream_json:
+    if supports_streaming:
         return _run_agent_streaming(
             cmd,
             prompt,

--- a/src/ralphify/_agent.py
+++ b/src/ralphify/_agent.py
@@ -82,6 +82,34 @@ _THREAD_JOIN_TIMEOUT = 5.0
 _PROCESS_WAIT_TIMEOUT = 5.0
 
 
+def _extract_result_text_from_lines(lines: list[str] | None) -> str | None:
+    """Return the last string payload from any JSON ``result`` event in *lines*."""
+    if lines is None:
+        return None
+
+    result_text = None
+    for line in lines:
+        extracted = _extract_result_text_from_line(line)
+        if extracted is not None:
+            result_text = extracted
+    return result_text
+
+
+def _extract_result_text_from_line(line: str) -> str | None:
+    """Return the string payload from a single JSON ``result`` event line."""
+    try:
+        parsed = json.loads(line.strip())
+    except json.JSONDecodeError:
+        return None
+    if (
+        isinstance(parsed, dict)
+        and parsed.get("type") == _RESULT_EVENT_TYPE
+        and isinstance(parsed.get(_RESULT_FIELD), str)
+    ):
+        return parsed[_RESULT_FIELD]
+    return None
+
+
 def _try_graceful_group_kill(proc: subprocess.Popen[Any]) -> bool:
     """Attempt to kill the process via its POSIX process group.
 
@@ -237,7 +265,7 @@ class AgentResult(ProcessResult):
 class _StreamResult:
     """Accumulated output from reading the agent's JSON stream."""
 
-    stdout_lines: tuple[str, ...]
+    stdout_lines: tuple[str, ...] | None
     result_text: str | None
     timed_out: bool
 
@@ -298,6 +326,8 @@ def _read_agent_stream(
     deadline: float | None,
     on_activity: ActivityCallback | None,
     on_output_line: OutputLineCallback | None = None,
+    *,
+    capture_stdout: bool = True,
 ) -> _StreamResult:
     """Read the agent's JSON stream line-by-line until EOF or timeout.
 
@@ -322,8 +352,12 @@ def _read_agent_stream(
 
     Returns early with ``timed_out=True`` when the deadline is exceeded,
     leaving the caller responsible for killing the subprocess.
+
+    When *capture_stdout* is ``False``, stdout is still drained and parsed but
+    not retained in memory.  This keeps the streaming path lightweight when no
+    later completion-signal parsing or log writing needs the raw bytes.
     """
-    stdout_lines: list[str] = []
+    stdout_lines: list[str] | None = [] if capture_stdout else None
     result_text: str | None = None
 
     line_q: queue.Queue[str | None] = queue.Queue()
@@ -347,19 +381,20 @@ def _read_agent_stream(
         except queue.Empty:
             # Deadline expired while waiting for a line.
             return _StreamResult(
-                stdout_lines=tuple(stdout_lines),
+                stdout_lines=tuple(stdout_lines) if stdout_lines is not None else None,
                 result_text=result_text,
                 timed_out=True,
             )
 
         if line is None:  # EOF sentinel from reader thread
             return _StreamResult(
-                stdout_lines=tuple(stdout_lines),
+                stdout_lines=tuple(stdout_lines) if stdout_lines is not None else None,
                 result_text=result_text,
                 timed_out=False,
             )
 
-        stdout_lines.append(line)
+        if stdout_lines is not None:
+            stdout_lines.append(line)
         if on_output_line is not None:
             try:
                 on_output_line(line.rstrip("\r\n"), _STDOUT)
@@ -390,7 +425,7 @@ def _read_agent_stream(
         # past the deadline.
         if deadline is not None and time.monotonic() > deadline:
             return _StreamResult(
-                stdout_lines=tuple(stdout_lines),
+                stdout_lines=tuple(stdout_lines) if stdout_lines is not None else None,
                 result_text=result_text,
                 timed_out=True,
             )
@@ -404,6 +439,8 @@ def _run_agent_streaming(
     iteration: int,
     on_activity: ActivityCallback | None = None,
     on_output_line: OutputLineCallback | None = None,
+    capture_result_text: bool = False,
+    capture_stdout: bool = False,
 ) -> AgentResult:
     """Run the agent subprocess with line-by-line streaming of JSON output.
 
@@ -420,30 +457,37 @@ def _run_agent_streaming(
     start = time.monotonic()
     deadline = (start + timeout) if timeout is not None else None
 
+    capture_stdout_text = log_dir is not None or capture_stdout
+    pipe_stderr = log_dir is not None or on_output_line is not None
+    capture_stderr_text = log_dir is not None
+
     writer_thread: threading.Thread | None = None
-    stderr_lines: list[str] = []
+    stderr_lines: list[str] | None = [] if capture_stderr_text else None
     stderr_thread: threading.Thread | None = None
 
     proc = subprocess.Popen(
         stream_cmd,
         stdin=subprocess.PIPE,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stderr=subprocess.PIPE if pipe_stderr else None,
         **SUBPROCESS_TEXT_KWARGS,
         **SESSION_KWARGS,
     )
     try:
         # Popen with PIPE guarantees non-None streams; guard explicitly
         # so the type checker narrows and -O mode cannot skip the check.
-        if proc.stdin is None or proc.stdout is None or proc.stderr is None:
+        if proc.stdin is None or proc.stdout is None:
             raise RuntimeError("subprocess.Popen failed to create PIPE streams")
+        if pipe_stderr and proc.stderr is None:
+            raise RuntimeError("subprocess.Popen failed to create PIPE stderr")
 
         # Start the stderr pump BEFORE writing stdin so large prompts can't
         # deadlock against an agent that writes substantial diagnostics to
         # stderr while still reading its stdin.
-        stderr_thread = _start_pump_thread(
-            proc.stderr, stderr_lines, _STDERR, on_output_line
-        )
+        if proc.stderr is not None:
+            stderr_thread = _start_pump_thread(
+                proc.stderr, stderr_lines, _STDERR, on_output_line
+            )
 
         # Deliver the prompt on a background thread so that a blocked write
         # (child not reading stdin, pipe buffer full) cannot prevent
@@ -452,7 +496,13 @@ def _run_agent_streaming(
         # _deliver_prompt already swallows.
         writer_thread = _start_writer_thread(proc, prompt)
 
-        stream = _read_agent_stream(proc.stdout, deadline, on_activity, on_output_line)
+        stream = _read_agent_stream(
+            proc.stdout,
+            deadline,
+            on_activity,
+            on_output_line,
+            capture_stdout=capture_stdout_text,
+        )
 
         if stream.timed_out:
             _kill_process_group(proc)
@@ -460,8 +510,8 @@ def _run_agent_streaming(
     finally:
         _cleanup_agent(proc, stderr_thread, writer_thread)
 
-    stdout = "".join(stream.stdout_lines)
-    stderr = "".join(stderr_lines)
+    stdout = "".join(stream.stdout_lines) if stream.stdout_lines is not None else None
+    stderr = "".join(stderr_lines) if stderr_lines is not None else None
 
     log_file = _write_log(log_dir, iteration, stdout, stderr)
 
@@ -471,8 +521,8 @@ def _run_agent_streaming(
         log_file=log_file,
         result_text=stream.result_text,
         timed_out=stream.timed_out,
-        captured_stdout=stdout if log_dir is not None else None,
-        captured_stderr=stderr if log_dir is not None else None,
+        captured_stdout=stdout if capture_stdout_text else None,
+        captured_stderr=stderr if capture_stderr_text else None,
     )
 
 
@@ -601,6 +651,8 @@ def _run_agent_blocking(
     log_dir: Path | None,
     iteration: int,
     on_output_line: OutputLineCallback | None = None,
+    capture_result_text: bool = False,
+    capture_stdout: bool = False,
 ) -> AgentResult:
     """Run the agent subprocess and return the result.
 
@@ -613,9 +665,9 @@ def _run_agent_blocking(
     - **Callback only** (``on_output_line`` set, no log dir) — reader
       threads forward lines to the callback without accumulating them,
       avoiding unbounded memory growth.
-    - **Log capture** (``log_dir`` set) — reader threads accumulate
-      lines into lists for log writing; lines are also forwarded to the
-      callback if provided.
+    - **Buffered capture** (``log_dir`` or ``capture_stdout`` set) —
+       reader threads accumulate lines for log writing or later completion
+       parsing; lines are also forwarded to the callback if provided.
 
     The subprocess is started in its own process group so that on
     ``KeyboardInterrupt`` or timeout the entire child tree can be killed
@@ -625,7 +677,12 @@ def _run_agent_blocking(
     Raises ``FileNotFoundError`` if the command binary does not exist.
     """
     start = time.monotonic()
-    capture = log_dir is not None or on_output_line is not None
+    capture_stdout_text = log_dir is not None or capture_stdout
+    capture_stderr_text = log_dir is not None
+    pipe_stdout = (
+        capture_stdout_text or on_output_line is not None or capture_result_text
+    )
+    pipe_stderr = capture_stderr_text or on_output_line is not None
 
     # When no subscriber needs the bytes, stdout/stderr are left
     # un-piped so the child writes directly to the terminal.  When
@@ -638,29 +695,41 @@ def _run_agent_blocking(
     writer_thread: threading.Thread | None = None
     stdout_thread: threading.Thread | None = None
     stderr_thread: threading.Thread | None = None
-    stdout_lines: list[str] | None = [] if log_dir is not None else None
-    stderr_lines: list[str] | None = [] if log_dir is not None else None
+    stdout_lines: list[str] | None = [] if capture_stdout_text else None
+    stderr_lines: list[str] | None = [] if capture_stderr_text else None
+    result_text: str | None = None
 
-    pipe = subprocess.PIPE if capture else None
+    def _on_output_line(line: str, stream_name: OutputStream) -> None:
+        nonlocal result_text
+        if capture_result_text and stream_name == _STDOUT:
+            extracted = _extract_result_text_from_line(line)
+            if extracted is not None:
+                result_text = extracted
+        if on_output_line is not None:
+            on_output_line(line, stream_name)
+
     proc = subprocess.Popen(
         cmd,
         stdin=subprocess.PIPE,
-        stdout=pipe,
-        stderr=pipe,
+        stdout=subprocess.PIPE if pipe_stdout else None,
+        stderr=subprocess.PIPE if pipe_stderr else None,
         **SUBPROCESS_TEXT_KWARGS,
         **SESSION_KWARGS,
     )
     try:
         if proc.stdin is None:
             raise RuntimeError("subprocess.Popen failed to create PIPE stdin")
-        if capture:
-            if proc.stdout is None or proc.stderr is None:
-                raise RuntimeError("subprocess.Popen failed to create PIPE streams")
+        if pipe_stdout:
+            if proc.stdout is None:
+                raise RuntimeError("subprocess.Popen failed to create PIPE stdout")
             stdout_thread = _start_pump_thread(
-                proc.stdout, stdout_lines, _STDOUT, on_output_line
+                proc.stdout, stdout_lines, _STDOUT, _on_output_line
             )
+        if pipe_stderr:
+            if proc.stderr is None:
+                raise RuntimeError("subprocess.Popen failed to create PIPE stderr")
             stderr_thread = _start_pump_thread(
-                proc.stderr, stderr_lines, _STDERR, on_output_line
+                proc.stderr, stderr_lines, _STDERR, _on_output_line
             )
 
         writer_thread = _start_writer_thread(proc, prompt)
@@ -681,9 +750,10 @@ def _run_agent_blocking(
         returncode=None if timed_out else returncode,
         elapsed=time.monotonic() - start,
         log_file=log_file,
+        result_text=result_text or _extract_result_text_from_lines(stdout_lines),
         timed_out=timed_out,
-        captured_stdout=stdout,
-        captured_stderr=stderr,
+        captured_stdout=stdout if capture_stdout_text else None,
+        captured_stderr=stderr if capture_stderr_text else None,
     )
 
 
@@ -696,6 +766,8 @@ def execute_agent(
     iteration: int,
     on_activity: ActivityCallback | None = None,
     on_output_line: OutputLineCallback | None = None,
+    capture_result_text: bool = False,
+    capture_stdout: bool | None = None,
 ) -> AgentResult:
     """Run the agent subprocess, auto-selecting streaming or blocking mode.
 
@@ -708,7 +780,13 @@ def execute_agent(
     This is the single entry point the engine should use — callers don't need
     to know which execution mode is selected.
     """
-    if _supports_stream_json(cmd):
+    supports_stream_json = _supports_stream_json(cmd)
+    if capture_stdout is None:
+        capture_stdout = log_dir is not None or (
+            not supports_stream_json and on_output_line is None and capture_result_text
+        )
+
+    if supports_stream_json:
         return _run_agent_streaming(
             cmd,
             prompt,
@@ -717,6 +795,8 @@ def execute_agent(
             iteration,
             on_activity=on_activity,
             on_output_line=on_output_line,
+            capture_result_text=capture_result_text,
+            capture_stdout=capture_stdout,
         )
     return _run_agent_blocking(
         cmd,
@@ -725,4 +805,6 @@ def execute_agent(
         log_dir,
         iteration,
         on_output_line=on_output_line,
+        capture_result_text=capture_result_text,
+        capture_stdout=capture_stdout,
     )

--- a/src/ralphify/_console_emitter.py
+++ b/src/ralphify/_console_emitter.py
@@ -42,8 +42,8 @@ from ralphify._events import (
     RunStoppedData,
 )
 from ralphify import _brand
-from ralphify._agent import CLAUDE_BINARY
 from ralphify._output import format_count, format_duration
+from ralphify.adapters import select_adapter
 
 _ICON_SUCCESS = "✓"
 _ICON_FAILURE = "✗"
@@ -106,18 +106,22 @@ _PEEK_OFF_MSG = (
     f"shift+{PEEK_TOGGLE_KEY} for full view[/]"
 )
 
-# ── Claude binary detection ───────────────────────────────────────────
+# ── Adapter-driven structured-output detection ────────────────────────
 
 
-def _is_claude_command(agent: str) -> bool:
-    """Return True if *agent* is a Claude Code command."""
+def _agent_renders_structured_peek(agent: str) -> bool:
+    """Return True if *agent*'s adapter feeds the structured peek panel.
+
+    Drives the ``ConsoleEmitter`` choice between :class:`_IterationPanel`
+    (structured) and :class:`_IterationSpinner` (raw).  Delegates to
+    :func:`select_adapter` so adding a new CLI with peek-panel support
+    requires no edits here.
+    """
     try:
-        parts = shlex.split(agent)
+        cmd = shlex.split(agent)
     except ValueError:
         return False
-    if not parts:
-        return False
-    return Path(parts[0]).stem == CLAUDE_BINARY
+    return select_adapter(cmd).renders_structured_peek
 
 
 # ── Tool argument abbreviation ────────────────────────────────────────
@@ -1248,7 +1252,7 @@ class ConsoleEmitter:
     def _on_run_started(self, data: RunStartedData) -> None:
         ralph_name = data["ralph_name"]
         agent = data["agent"]
-        self._structured_agent = _is_claude_command(agent)
+        self._structured_agent = _agent_renders_structured_peek(agent)
         with self._console_lock:
             self._console.print(
                 f"\n[bold {_brand.PURPLE}]{_ICON_PLAY} Running:[/] [bold]{escape_markup(ralph_name)}[/]"

--- a/src/ralphify/_frontmatter.py
+++ b/src/ralphify/_frontmatter.py
@@ -26,6 +26,10 @@ FIELD_COMMANDS = "commands"
 FIELD_ARGS = "args"
 FIELD_CREDIT = "credit"
 FIELD_RALPH = "ralph"
+# Promise config keeps the legacy key names. ``completion_signal`` stores the
+# inner promise text, not the surrounding ``<promise>...</promise>`` markup.
+FIELD_COMPLETION_SIGNAL = "completion_signal"
+FIELD_STOP_ON_COMPLETION_SIGNAL = "stop_on_completion_signal"
 
 # Sub-field names within each command mapping.
 CMD_FIELD_NAME = "name"

--- a/src/ralphify/_promise.py
+++ b/src/ralphify/_promise.py
@@ -1,0 +1,27 @@
+"""Parse promise completion tags emitted by agents."""
+
+from __future__ import annotations
+
+import re
+
+_PROMISE_TAG_RE = re.compile(r"<promise>(.*?)</promise>", re.DOTALL)
+
+
+def _normalize_promise_text(text: str) -> str:
+    """Collapse internal whitespace so config and tag payloads compare consistently."""
+    return " ".join(text.split())
+
+
+def parse_promise_tags(text: str | None) -> list[str]:
+    """Return normalized inner text from all well-formed promise tags in *text*."""
+    if not text:
+        return []
+    return [
+        _normalize_promise_text(match.group(1))
+        for match in _PROMISE_TAG_RE.finditer(text)
+    ]
+
+
+def has_promise_completion(text: str | None, completion_signal: str) -> bool:
+    """Return True when *text* contains a matching promise completion tag."""
+    return _normalize_promise_text(completion_signal) in parse_promise_tags(text)

--- a/src/ralphify/_run_types.py
+++ b/src/ralphify/_run_types.py
@@ -20,6 +20,9 @@ from ralphify._events import STOP_COMPLETED, STOP_ERROR, STOP_USER_REQUESTED, St
 DEFAULT_COMMAND_TIMEOUT: float = 60
 """Default timeout in seconds for commands defined in RALPH.md frontmatter."""
 
+DEFAULT_COMPLETION_SIGNAL = "RALPH_PROMISE_COMPLETE"
+"""Default inner ``<promise>...</promise>`` text that marks promise completion."""
+
 RUN_ID_LENGTH: int = 12
 """Number of hex characters used for generated run IDs."""
 
@@ -97,6 +100,10 @@ class RunConfig:
     log_dir: Path | None = None
     project_root: Path = field(default=Path("."))
     credit: bool = True
+    # Inner text expected inside ``<promise>...</promise>``.
+    completion_signal: str = DEFAULT_COMPLETION_SIGNAL
+    # Stop the run when the configured promise payload is observed.
+    stop_on_completion_signal: bool = False
 
 
 @dataclass(slots=True)
@@ -120,6 +127,7 @@ class RunState:
     failed: int = 0
     timed_out_count: int = 0
     started_at: datetime | None = None
+    promise_completed: bool = False
 
     _stop_event: threading.Event = field(
         default_factory=threading.Event, init=False, repr=False, compare=False
@@ -134,27 +142,22 @@ class RunState:
         return self.completed + self.failed
 
     def __post_init__(self) -> None:
-        # Set initially: the run starts in an unpaused (resumed) state.
         self._resume_event.set()
 
     def request_stop(self) -> None:
-        """Signal the loop to stop after the current iteration."""
         self._stop_event.set()
         self._resume_event.set()
 
     def request_pause(self) -> None:
-        """Pause the loop between iterations until resumed."""
         self.status = RunStatus.PAUSED
         self._resume_event.clear()
 
     def request_resume(self) -> None:
-        """Resume a paused loop."""
         self.status = RunStatus.RUNNING
         self._resume_event.set()
 
     @property
     def stop_requested(self) -> bool:
-        """Whether a stop has been requested."""
         return self._stop_event.is_set()
 
     def wait_for_stop(self, timeout: float | None = None) -> bool:
@@ -163,7 +166,6 @@ class RunState:
 
     @property
     def paused(self) -> bool:
-        """Whether the run is currently paused."""
         return not self._resume_event.is_set()
 
     def wait_for_unpause(self, timeout: float | None = None) -> bool:
@@ -171,11 +173,9 @@ class RunState:
         return self._resume_event.wait(timeout=timeout)
 
     def mark_completed(self) -> None:
-        """Record a successful iteration."""
         self.completed += 1
 
     def mark_failed(self) -> None:
-        """Record a failed iteration."""
         self.failed += 1
 
     def mark_timed_out(self) -> None:

--- a/src/ralphify/adapters/__init__.py
+++ b/src/ralphify/adapters/__init__.py
@@ -1,0 +1,158 @@
+"""Pluggable CLI adapter layer.
+
+Each supported agent CLI (Claude, Codex, Copilot, ...) implements the
+:class:`CLIAdapter` protocol in its own module under this package.  The
+engine dispatches on :func:`select_adapter` at run time, so adding a new
+CLI means writing one file and registering it in :data:`ADAPTERS` — no
+edits to the engine, emitter, or subprocess machinery.
+
+Adapters translate the CLI's native output format to a common
+:class:`AdapterEvent` stream and advertise capability flags so the core
+loop can gracefully degrade when a CLI lacks structured output or hook
+injection.  Process lifecycle (spawn, SIGTERM at cap, reap) stays in
+``_agent.py``; adapters only observe.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal, NamedTuple, Protocol, runtime_checkable
+
+
+AdapterEventKind = Literal["tool_use", "turn", "message", "result"]
+"""Categories of events an adapter can surface from a CLI's output stream."""
+
+CountsWhat = Literal["tool_use", "turn", "none"]
+"""What an adapter counts against ``max_turns`` — tool uses, turns, or nothing."""
+
+
+class AdapterEvent(NamedTuple):
+    """A single structured event parsed from a CLI's output stream.
+
+    ``kind`` is the event category; ``name`` carries a tool name for
+    ``tool_use`` events (``None`` otherwise); ``raw`` is the original
+    parsed JSON object so callers can inspect extra fields when needed.
+    """
+
+    kind: AdapterEventKind
+    name: str | None = None
+    raw: dict | None = None
+
+
+@runtime_checkable
+class CLIAdapter(Protocol):
+    """Protocol every CLI adapter must satisfy.
+
+    Adapters are stateless singletons: the same instance is reused for
+    every iteration of every run.  Any per-iteration state lives in the
+    caller (``_agent.py``) — adapters only translate.
+    """
+
+    name: str
+    counts_what: CountsWhat
+    supports_streaming: bool
+    renders_structured_peek: bool
+    supports_soft_wind_down: bool
+    requires_full_stdout_for_completion: bool
+
+    def matches(self, cmd: list[str]) -> bool:
+        """Return True if this adapter handles the given agent command."""
+        ...
+
+    def build_command(self, cmd: list[str]) -> list[str]:
+        """Return the command with any adapter-required flags appended.
+
+        Idempotent: calling twice returns the same command.
+        """
+        ...
+
+    def parse_event(self, line: str) -> AdapterEvent | None:
+        """Parse one line of stdout into an :class:`AdapterEvent`.
+
+        Returns ``None`` for lines that are not recognised events.
+        MUST NOT raise on malformed input (per FR-8).
+        """
+        ...
+
+    def extract_completion_signal(
+        self,
+        *,
+        result_text: str | None,
+        stdout: str | None,
+        user_signal: str,
+    ) -> bool:
+        """Return True if the agent's final output contains the completion signal.
+
+        The signal is wrapped in ``<promise>...</promise>`` markup; the
+        inner text equals ``user_signal``.
+
+        Adapters receive both the streaming-extracted *result_text* (the
+        terminal assistant message, when the streaming path could parse one)
+        and the full *stdout* buffer (only present when the engine chose to
+        capture it).  Adapters with ``requires_full_stdout_for_completion``
+        set False MUST be able to detect completion from *result_text* alone;
+        engines may pass ``stdout=None`` to skip the memory cost.
+        """
+        ...
+
+    def install_wind_down_hook(
+        self,
+        tempdir: Path,
+        counter_path: Path,
+        cap: int,
+        grace: int,
+    ) -> dict[str, str]:
+        """Write hook config files into *tempdir* and return env-var overrides.
+
+        Only called when ``supports_soft_wind_down`` is True.  Adapters that
+        set the flag False may leave this unimplemented (a ``NotImplementedError``
+        is acceptable and is treated as a runtime downgrade to hard-cap-only).
+        """
+        ...
+
+
+ADAPTERS: list[CLIAdapter] = []
+"""Adapter registry, populated at import time by concrete adapter modules.
+
+Ordering matters: :func:`select_adapter` returns the first adapter whose
+``matches`` method returns True, with :class:`GenericAdapter` as a final
+catch-all.  Specific adapters go first, generic last.
+"""
+
+
+def select_adapter(cmd: list[str]) -> CLIAdapter:
+    """Return the first registered adapter that claims *cmd*.
+
+    Falls back to :class:`GenericAdapter` when nothing matches.  Never
+    returns None — callers can always dispatch safely.
+    """
+    from ralphify.adapters._generic import GenericAdapter
+
+    for adapter in ADAPTERS:
+        if adapter.matches(cmd):
+            return adapter
+    return GenericAdapter()
+
+
+def _register_builtin_adapters() -> None:
+    """Import concrete adapter modules so their ``ADAPTERS.append`` runs.
+
+    Keeps the registry populated without forcing callers to import every
+    adapter module manually.  Imports are deferred to the bottom of this
+    module (executed once at first package import) so cyclic-import risk
+    is contained.
+    """
+    from ralphify.adapters import claude, codex, copilot  # noqa: F401
+
+
+_register_builtin_adapters()
+
+
+__all__ = [
+    "ADAPTERS",
+    "AdapterEvent",
+    "AdapterEventKind",
+    "CLIAdapter",
+    "CountsWhat",
+    "select_adapter",
+]

--- a/src/ralphify/adapters/__init__.py
+++ b/src/ralphify/adapters/__init__.py
@@ -39,6 +39,30 @@ class AdapterEvent(NamedTuple):
     raw: dict | None = None
 
 
+class CacheStats(NamedTuple):
+    """Prompt-cache token accounting for a single model call.
+
+    Counts are input-side tokens only (caching does not apply to output):
+
+    - ``read_tokens``    — input served from cache (the cheap tokens).
+    - ``write_tokens``   — input newly written to cache this call.  Claude
+      reports this as ``cache_creation_input_tokens``; APIs that do not
+      distinguish creation from a regular miss (e.g. OpenAI Responses)
+      report ``0`` here.
+    - ``uncached_tokens`` — input that bypassed cache entirely.
+
+    Total prompt tokens are ``read + write + uncached``.  A ratio of
+    ``read_tokens / (read + write + uncached)`` gives the effective cache
+    hit rate for that call.  Adapters return ``None`` from
+    :meth:`CLIAdapter.extract_cache_stats` when an event carries no usage
+    payload, so callers can distinguish "no data" from "zero cache hits".
+    """
+
+    read_tokens: int
+    write_tokens: int
+    uncached_tokens: int
+
+
 @runtime_checkable
 class CLIAdapter(Protocol):
     """Protocol every CLI adapter must satisfy.
@@ -54,6 +78,7 @@ class CLIAdapter(Protocol):
     renders_structured_peek: bool
     supports_soft_wind_down: bool
     requires_full_stdout_for_completion: bool
+    supports_prompt_caching: bool
 
     def matches(self, cmd: list[str]) -> bool:
         """Return True if this adapter handles the given agent command."""
@@ -110,6 +135,22 @@ class CLIAdapter(Protocol):
         """
         ...
 
+    def extract_cache_stats(self, raw: dict) -> CacheStats | None:
+        """Return prompt-cache token accounting for a single parsed event.
+
+        Called once per :class:`AdapterEvent` the caller wants stats for —
+        typically the terminal ``result`` event, but adapters that emit
+        per-turn usage may surface stats on every turn boundary too.
+        Returns ``None`` when *raw* has no usage payload (not every event
+        carries one).
+
+        Adapters with ``supports_prompt_caching`` set False MAY always
+        return ``None``; the flag signals "this CLI has no observable
+        caching story", whereas ``None`` from a capable adapter just means
+        "this particular event had no usage data".
+        """
+        ...
+
 
 ADAPTERS: list[CLIAdapter] = []
 """Adapter registry, populated at import time by concrete adapter modules.
@@ -153,6 +194,7 @@ __all__ = [
     "AdapterEvent",
     "AdapterEventKind",
     "CLIAdapter",
+    "CacheStats",
     "CountsWhat",
     "select_adapter",
 ]

--- a/src/ralphify/adapters/_generic.py
+++ b/src/ralphify/adapters/_generic.py
@@ -1,0 +1,70 @@
+"""Fallback adapter for CLIs with no dedicated implementation.
+
+Returned by :func:`ralphify.adapters.select_adapter` when no specific
+adapter's ``matches`` returns True.  All capability flags are False, so
+the core loop treats sessions as blocking, untyped, and uncappable.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ralphify._promise import has_promise_completion
+from ralphify.adapters import AdapterEvent, CountsWhat
+
+
+class GenericAdapter:
+    """No-op adapter: pass commands through unchanged, parse nothing."""
+
+    name: str = "generic"
+    counts_what: CountsWhat = "none"
+    supports_streaming: bool = False
+    renders_structured_peek: bool = False
+    supports_soft_wind_down: bool = False
+    # Untyped agents have no streaming result event; the engine must keep
+    # the full stdout buffer if it wants promise detection.
+    requires_full_stdout_for_completion: bool = True
+
+    def matches(self, cmd: list[str]) -> bool:
+        return False
+
+    def build_command(self, cmd: list[str]) -> list[str]:
+        return list(cmd)
+
+    def parse_event(self, line: str) -> AdapterEvent | None:
+        return None
+
+    def extract_completion_signal(
+        self,
+        *,
+        result_text: str | None,
+        stdout: str | None,
+        user_signal: str,
+    ) -> bool:
+        """Scan the full stdout for the promise tag.
+
+        Unknown CLIs have no event schema to parse, so the whole-stdout
+        regex scan is the only reliable path.  Matches the current
+        engine-side behavior so switching to adapter-owned detection does
+        not regress promise completion for untyped agents.
+
+        *result_text* is unused (the blocking path does not populate it
+        for unknown CLIs); the engine opts into
+        ``requires_full_stdout_for_completion`` to make sure *stdout* is
+        supplied when promise detection is requested.
+        """
+        del result_text
+        if stdout is None:
+            return False
+        return has_promise_completion(stdout, user_signal)
+
+    def install_wind_down_hook(
+        self,
+        tempdir: Path,
+        counter_path: Path,
+        cap: int,
+        grace: int,
+    ) -> dict[str, str]:
+        raise NotImplementedError(
+            "GenericAdapter does not support soft wind-down; max_turns will hard-kill."
+        )

--- a/src/ralphify/adapters/_generic.py
+++ b/src/ralphify/adapters/_generic.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from ralphify._promise import has_promise_completion
-from ralphify.adapters import AdapterEvent, CountsWhat
+from ralphify.adapters import AdapterEvent, CacheStats, CountsWhat
 
 
 class GenericAdapter:
@@ -24,6 +24,9 @@ class GenericAdapter:
     # Untyped agents have no streaming result event; the engine must keep
     # the full stdout buffer if it wants promise detection.
     requires_full_stdout_for_completion: bool = True
+    # Unknown CLI — no schema to extract usage from, so treat caching as
+    # unobservable.  ``extract_cache_stats`` always returns ``None``.
+    supports_prompt_caching: bool = False
 
     def matches(self, cmd: list[str]) -> bool:
         return False
@@ -68,3 +71,8 @@ class GenericAdapter:
         raise NotImplementedError(
             "GenericAdapter does not support soft wind-down; max_turns will hard-kill."
         )
+
+    def extract_cache_stats(self, raw: dict) -> CacheStats | None:
+        """Unknown CLI — no parseable usage schema.  Always ``None``."""
+        del raw
+        return None

--- a/src/ralphify/adapters/claude.py
+++ b/src/ralphify/adapters/claude.py
@@ -1,0 +1,172 @@
+"""Claude Code adapter.
+
+Claude is the only CLI shipping a stable ``--output-format stream-json``
+protocol today; its structured events drive the peek panel and power
+per-event tool-use counting.  Every Claude iteration emits:
+
+1. A ``system`` init event with the model name.
+2. Zero or more ``assistant`` messages whose ``content`` list may include
+   ``tool_use``, ``thinking``, and ``text`` blocks.
+3. Zero or more ``user`` messages (tool results echoed back).
+4. A terminal ``result`` event carrying the final assistant text.
+
+Tool-use counting is scoped to ``assistant`` messages; we ignore
+``tool_use`` blocks echoed back by ``user`` events so each invocation is
+counted exactly once.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ralphify._promise import has_promise_completion
+from ralphify.adapters import ADAPTERS, AdapterEvent, CountsWhat
+
+
+CLAUDE_BINARY_STEM = "claude"
+"""Binary stem (``Path(cmd[0]).stem``) that identifies the Claude CLI."""
+
+_OUTPUT_FORMAT_FLAG = "--output-format"
+_OUTPUT_FORMAT_VALUE = "stream-json"
+_VERBOSE_FLAG = "--verbose"
+
+_EVENT_TYPE_ASSISTANT = "assistant"
+_EVENT_TYPE_RESULT = "result"
+_BLOCK_TYPE_TOOL_USE = "tool_use"
+
+
+class ClaudeAdapter:
+    """Parses Claude's stream-json output and supports soft wind-down."""
+
+    name: str = "claude"
+    counts_what: CountsWhat = "tool_use"
+    supports_streaming: bool = True
+    renders_structured_peek: bool = True
+    supports_soft_wind_down: bool = True
+    # Claude's final assistant text already arrives as ``agent.result_text``
+    # via the stream-json ``result`` event, so the engine does not need to
+    # buffer the full stdout to scan for the promise tag.
+    requires_full_stdout_for_completion: bool = False
+
+    def matches(self, cmd: list[str]) -> bool:
+        if not cmd:
+            return False
+        return Path(cmd[0]).stem == CLAUDE_BINARY_STEM
+
+    def build_command(self, cmd: list[str]) -> list[str]:
+        """Ensure ``--output-format stream-json --verbose`` is present.
+
+        Idempotent: running twice yields the same command. If the caller
+        already supplied ``--output-format <other>``, the existing value is
+        overwritten with ``stream-json`` — we cannot honor a user-chosen
+        format while still emitting a parseable event stream.
+        """
+        result = list(cmd)
+        try:
+            format_index = result.index(_OUTPUT_FORMAT_FLAG)
+        except ValueError:
+            result.extend([_OUTPUT_FORMAT_FLAG, _OUTPUT_FORMAT_VALUE])
+        else:
+            value_index = format_index + 1
+            if value_index < len(result):
+                result[value_index] = _OUTPUT_FORMAT_VALUE
+            else:
+                result.append(_OUTPUT_FORMAT_VALUE)
+        if _VERBOSE_FLAG not in result:
+            result.append(_VERBOSE_FLAG)
+        return result
+
+    def parse_event(self, line: str) -> AdapterEvent | None:
+        """Parse one stream-json line into an :class:`AdapterEvent`.
+
+        Empty lines, non-JSON payloads, and non-dict JSON return ``None``.
+        ``result`` events return ``AdapterEvent(kind="result")``. An
+        ``assistant`` event whose content contains a ``tool_use`` block
+        returns the first such block as ``AdapterEvent(kind="tool_use")``;
+        Claude emits one tool_use block per assistant message, so
+        single-event dispatch matches the protocol. Every other parsed
+        event dict — including non-tool-use ``assistant`` messages —
+        returns ``AdapterEvent(kind="message")`` so callers can still
+        render them without counting against the turn cap.
+        """
+        stripped = line.strip()
+        if not stripped:
+            return None
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(parsed, dict):
+            return None
+
+        event_type = parsed.get("type")
+        if event_type == _EVENT_TYPE_RESULT:
+            return AdapterEvent(kind="result", raw=parsed)
+        if event_type != _EVENT_TYPE_ASSISTANT:
+            return AdapterEvent(kind="message", raw=parsed)
+
+        for block in _iter_content_blocks(parsed):
+            if block.get("type") == _BLOCK_TYPE_TOOL_USE:
+                name = block.get("name")
+                return AdapterEvent(
+                    kind="tool_use",
+                    name=name if isinstance(name, str) else None,
+                    raw=parsed,
+                )
+        return AdapterEvent(kind="message", raw=parsed)
+
+    def extract_completion_signal(
+        self,
+        *,
+        result_text: str | None,
+        stdout: str | None,
+        user_signal: str,
+    ) -> bool:
+        """Scan the streaming-extracted result text for ``<promise>{signal}</promise>``.
+
+        Claude's terminal ``result`` event carries the last assistant
+        message as a plain string, which the streaming reader already
+        captures into :attr:`AgentResult.result_text`.  Using *result_text*
+        directly avoids buffering the full stdout — large transcripts can
+        run into many megabytes per iteration.
+
+        Only the parsed result text is considered — raw JSON from
+        ``status`` or ``assistant`` messages can legitimately echo
+        ``<promise>...</promise>`` substrings that must not trigger
+        completion.
+
+        *stdout* is unused (Claude does not need a fallback because the
+        streaming path always populates *result_text* on a successful run);
+        it stays in the signature for protocol parity.
+        """
+        del stdout
+        if result_text is None:
+            return False
+        return has_promise_completion(result_text, user_signal)
+
+    def install_wind_down_hook(
+        self,
+        tempdir: Path,
+        counter_path: Path,
+        cap: int,
+        grace: int,
+    ) -> dict[str, str]:
+        raise NotImplementedError(
+            "Claude soft wind-down (settings.json PreToolUse hook) is scheduled "
+            "for Phase 3 of the CLI adapter layer spec."
+        )
+
+
+def _iter_content_blocks(raw: dict) -> list[dict]:
+    """Return the ``message.content`` list, filtered to dict blocks only."""
+    message = raw.get("message")
+    if not isinstance(message, dict):
+        return []
+    content = message.get("content")
+    if not isinstance(content, list):
+        return []
+    return [block for block in content if isinstance(block, dict)]
+
+
+ADAPTERS.append(ClaudeAdapter())

--- a/src/ralphify/adapters/claude.py
+++ b/src/ralphify/adapters/claude.py
@@ -21,7 +21,7 @@ import json
 from pathlib import Path
 
 from ralphify._promise import has_promise_completion
-from ralphify.adapters import ADAPTERS, AdapterEvent, CountsWhat
+from ralphify.adapters import ADAPTERS, AdapterEvent, CacheStats, CountsWhat
 
 
 CLAUDE_BINARY_STEM = "claude"
@@ -48,6 +48,13 @@ class ClaudeAdapter:
     # via the stream-json ``result`` event, so the engine does not need to
     # buffer the full stdout to scan for the promise tag.
     requires_full_stdout_for_completion: bool = False
+    # Claude Code auto-injects ``cache_control: ephemeral`` on the system
+    # prompt, CLAUDE.md, and tool defs.  Every assistant and result event
+    # carries a ``usage`` object with ``cache_creation_input_tokens`` and
+    # ``cache_read_input_tokens`` fields — we surface those as
+    # :class:`CacheStats` so ralph-loop iterations within the 5-minute TTL
+    # can be observed hitting cache.
+    supports_prompt_caching: bool = True
 
     def matches(self, cmd: list[str]) -> bool:
         if not cmd:
@@ -157,6 +164,32 @@ class ClaudeAdapter:
             "for Phase 3 of the CLI adapter layer spec."
         )
 
+    def extract_cache_stats(self, raw: dict) -> CacheStats | None:
+        """Extract ``CacheStats`` from a Claude stream-json event's usage block.
+
+        Usage lives at ``message.usage`` on ``assistant`` events and at
+        top-level ``usage`` on the terminal ``result`` event; both shapes
+        are accepted.  Returns ``None`` when no usage object is present or
+        has no readable integer fields — the caller can distinguish "event
+        had no usage" from zero-hit cache runs.
+
+        The three relevant fields are ``input_tokens`` (uncached input),
+        ``cache_creation_input_tokens`` (tokens written to cache this call),
+        and ``cache_read_input_tokens`` (tokens served from cache).  Missing
+        fields are treated as zero.
+        """
+        usage = _extract_usage_dict(raw)
+        if usage is None:
+            return None
+        read = _int_or_zero(usage.get("cache_read_input_tokens"))
+        write = _int_or_zero(usage.get("cache_creation_input_tokens"))
+        uncached = _int_or_zero(usage.get("input_tokens"))
+        if read == 0 and write == 0 and uncached == 0:
+            return None
+        return CacheStats(
+            read_tokens=read, write_tokens=write, uncached_tokens=uncached
+        )
+
 
 def _iter_content_blocks(raw: dict) -> list[dict]:
     """Return the ``message.content`` list, filtered to dict blocks only."""
@@ -167,6 +200,24 @@ def _iter_content_blocks(raw: dict) -> list[dict]:
     if not isinstance(content, list):
         return []
     return [block for block in content if isinstance(block, dict)]
+
+
+def _extract_usage_dict(raw: dict) -> dict | None:
+    """Return the usage dict from either top-level or nested ``message.usage``."""
+    usage = raw.get("usage")
+    if isinstance(usage, dict):
+        return usage
+    message = raw.get("message")
+    if isinstance(message, dict):
+        nested = message.get("usage")
+        if isinstance(nested, dict):
+            return nested
+    return None
+
+
+def _int_or_zero(value: object) -> int:
+    """Coerce a usage field to int; non-ints become zero."""
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
 
 ADAPTERS.append(ClaudeAdapter())

--- a/src/ralphify/adapters/codex.py
+++ b/src/ralphify/adapters/codex.py
@@ -20,7 +20,7 @@ import json
 from pathlib import Path
 
 from ralphify._promise import has_promise_completion
-from ralphify.adapters import ADAPTERS, AdapterEvent, CountsWhat
+from ralphify.adapters import ADAPTERS, AdapterEvent, CacheStats, CountsWhat
 
 
 CODEX_BINARY_STEM = "codex"
@@ -53,6 +53,14 @@ class CodexAdapter:
     # ``agent.result_text``.  The full stdout buffer is currently the only
     # source for promise-tag scanning.
     requires_full_stdout_for_completion: bool = True
+    # OpenAI's Responses API caches automatically; usage events carry a
+    # ``cached_tokens`` field under ``input_tokens_details`` (Responses) or
+    # ``prompt_tokens_details`` (older Chat shape).  We surface the count
+    # as :class:`CacheStats`, with ``write_tokens=0`` because OpenAI does
+    # not distinguish a cache write from a regular miss.  Caching is
+    # fragile — routing stickiness across fresh ``codex exec`` invocations
+    # is not guaranteed — but when hits occur, this is where we see them.
+    supports_prompt_caching: bool = True
 
     def matches(self, cmd: list[str]) -> bool:
         if not cmd:
@@ -146,6 +154,33 @@ class CodexAdapter:
             "for Phase 3 of the CLI adapter layer spec."
         )
 
+    def extract_cache_stats(self, raw: dict) -> CacheStats | None:
+        """Extract :class:`CacheStats` from a Codex event's usage payload.
+
+        Codex emits usage data either on a dedicated ``TokenCount`` event or
+        nested inside a ``TurnCompleted`` event; both shapes surface the
+        same ``usage`` dict.  We check ``usage.input_tokens_details.cached_tokens``
+        first (the Responses API shape) and fall through to the older
+        ``prompt_tokens_details.cached_tokens`` layout, mirroring what the
+        Codex CLI has emitted across its 2025–2026 builds.
+
+        OpenAI does not distinguish a cache write from a regular miss, so
+        ``write_tokens`` is always ``0`` for this adapter — the total
+        prompt cost splits cleanly between cached and uncached input.
+        Returns ``None`` when no usage dict is present.
+        """
+        usage = _extract_usage_dict(raw)
+        if usage is None:
+            return None
+        prompt_tokens = _int_or_zero(
+            usage.get("input_tokens") or usage.get("prompt_tokens")
+        )
+        cached = _int_or_zero(_nested_cached_tokens(usage))
+        if prompt_tokens == 0 and cached == 0:
+            return None
+        uncached = max(prompt_tokens - cached, 0)
+        return CacheStats(read_tokens=cached, write_tokens=0, uncached_tokens=uncached)
+
 
 def _event_type(parsed: dict) -> str | None:
     """Return the Codex event type, whether top-level or nested under ``type``."""
@@ -193,6 +228,35 @@ def _event_text_payload(parsed: dict) -> str | None:
             if isinstance(value, str):
                 return value
     return None
+
+
+def _extract_usage_dict(raw: dict) -> dict | None:
+    """Return the ``usage`` dict from either top-level or nested ``msg.usage``."""
+    usage = raw.get("usage")
+    if isinstance(usage, dict):
+        return usage
+    msg = raw.get("msg")
+    if isinstance(msg, dict):
+        nested = msg.get("usage")
+        if isinstance(nested, dict):
+            return nested
+    return None
+
+
+def _nested_cached_tokens(usage: dict) -> object:
+    """Return the cached-tokens value from either Responses or Chat usage shapes."""
+    for container_key in ("input_tokens_details", "prompt_tokens_details"):
+        container = usage.get(container_key)
+        if isinstance(container, dict):
+            cached = container.get("cached_tokens")
+            if cached is not None:
+                return cached
+    return usage.get("cached_tokens")
+
+
+def _int_or_zero(value: object) -> int:
+    """Coerce a usage field to int; non-ints and booleans become zero."""
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
 
 
 ADAPTERS.append(CodexAdapter())

--- a/src/ralphify/adapters/codex.py
+++ b/src/ralphify/adapters/codex.py
@@ -1,0 +1,198 @@
+"""Codex CLI adapter.
+
+Codex emits newline-delimited JSON with explicit event types:
+
+- ``TurnStarted`` / ``TurnCompleted`` — conversation turn boundaries.
+- ``CollabToolCall`` / ``McpToolCall`` — tool invocations initiated by
+  the agent.
+- ``CommandExecution`` — shell commands run inside the sandbox.
+
+We map every tool-call event to ``AdapterEvent(kind="tool_use", ...)``
+so the turn-cap counter uses the same user-facing metric across CLIs.
+Turn boundaries surface as ``kind="turn"`` events for adapters that want
+them; they do not count against ``max_turns`` today (counts_what is
+``tool_use``, not ``turn``, for a unified metric — see spec Q13).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ralphify._promise import has_promise_completion
+from ralphify.adapters import ADAPTERS, AdapterEvent, CountsWhat
+
+
+CODEX_BINARY_STEM = "codex"
+"""Binary stem (``Path(cmd[0]).stem``) that identifies the Codex CLI."""
+
+_JSON_FLAG = "--json"
+"""Flag appended to request newline-delimited JSON output."""
+
+_TURN_EVENTS: frozenset[str] = frozenset({"TurnStarted", "TurnCompleted"})
+_TOOL_CALL_EVENTS: frozenset[str] = frozenset(
+    {"CollabToolCall", "McpToolCall", "CommandExecution"}
+)
+_RESULT_EVENTS: frozenset[str] = frozenset({"TaskComplete", "TurnCompleted"})
+
+
+class CodexAdapter:
+    """Parses Codex's ``--json`` event stream."""
+
+    name: str = "codex"
+    counts_what: CountsWhat = "tool_use"
+    supports_streaming: bool = True
+    # Codex emits structured JSON that the streaming execution path parses
+    # for activity callbacks, but the console peek panel only understands
+    # Claude's stream-json schema today. Keep peek in raw-line mode until
+    # the emitter can render Codex events directly.
+    renders_structured_peek: bool = False
+    supports_soft_wind_down: bool = True
+    # Codex's terminal text lives inside ``TaskComplete`` / ``TurnCompleted``
+    # events, which the streaming reader does not extract into
+    # ``agent.result_text``.  The full stdout buffer is currently the only
+    # source for promise-tag scanning.
+    requires_full_stdout_for_completion: bool = True
+
+    def matches(self, cmd: list[str]) -> bool:
+        if not cmd:
+            return False
+        return Path(cmd[0]).stem == CODEX_BINARY_STEM
+
+    def build_command(self, cmd: list[str]) -> list[str]:
+        """Append ``--json`` to request structured output.  Idempotent."""
+        result = list(cmd)
+        if _JSON_FLAG not in result:
+            result.append(_JSON_FLAG)
+        return result
+
+    def parse_event(self, line: str) -> AdapterEvent | None:
+        """Classify one JSONL line as turn / tool_use / message / result.
+
+        Unknown event types return ``AdapterEvent(kind="message", ...)`` so
+        callers can still render them (e.g. peek panel) without counting
+        them against the turn cap.  Malformed lines return ``None``.
+        """
+        stripped = line.strip()
+        if not stripped:
+            return None
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(parsed, dict):
+            return None
+
+        event_type = _event_type(parsed)
+        if event_type in _TOOL_CALL_EVENTS:
+            return AdapterEvent(
+                kind="tool_use",
+                name=_tool_name(parsed, event_type),
+                raw=parsed,
+            )
+        if event_type in _RESULT_EVENTS:
+            return AdapterEvent(kind="result", raw=parsed)
+        if event_type in _TURN_EVENTS:
+            return AdapterEvent(kind="turn", raw=parsed)
+        return AdapterEvent(kind="message", raw=parsed)
+
+    def extract_completion_signal(
+        self,
+        *,
+        result_text: str | None,
+        stdout: str | None,
+        user_signal: str,
+    ) -> bool:
+        """Scan every ``TurnCompleted`` / ``TaskComplete`` event for the promise tag.
+
+        Codex does not carry a single terminal ``result`` string the way
+        Claude does; completion may be spread across assistant text in
+        multiple events.  Falling back to a whole-stdout scan is safe
+        because promise tags are explicit and non-ambiguous markup.
+
+        *result_text* is unused — Codex never populates it through the
+        streaming reader (no ``{"type":"result"}`` lines).  The engine
+        opts into ``requires_full_stdout_for_completion`` to make sure
+        *stdout* is supplied when promise detection is requested.
+        """
+        del result_text
+        if stdout is None:
+            return False
+        if has_promise_completion(stdout, user_signal):
+            return True
+        for line in stdout.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                parsed = json.loads(stripped)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(parsed, dict) and _event_type(parsed) in _RESULT_EVENTS:
+                text = _event_text_payload(parsed)
+                if text and has_promise_completion(text, user_signal):
+                    return True
+        return False
+
+    def install_wind_down_hook(
+        self,
+        tempdir: Path,
+        counter_path: Path,
+        cap: int,
+        grace: int,
+    ) -> dict[str, str]:
+        raise NotImplementedError(
+            "Codex soft wind-down (hooks.json PostToolUse) is scheduled "
+            "for Phase 3 of the CLI adapter layer spec."
+        )
+
+
+def _event_type(parsed: dict) -> str | None:
+    """Return the Codex event type, whether top-level or nested under ``type``."""
+    event_type = parsed.get("type") or parsed.get("kind")
+    if isinstance(event_type, str):
+        return event_type
+    msg = parsed.get("msg")
+    if isinstance(msg, dict):
+        nested = msg.get("type") or msg.get("kind")
+        if isinstance(nested, str):
+            return nested
+    return None
+
+
+def _tool_name(parsed: dict, event_type: str | None) -> str | None:
+    """Best-effort extraction of the tool name from a tool-call event.
+
+    Codex event shapes vary by tool type — ``CommandExecution`` carries a
+    command, ``CollabToolCall`` a tool name, ``McpToolCall`` a server +
+    tool.  When no specific name is available, return the event type.
+    """
+    for key in ("name", "tool", "tool_name"):
+        value = parsed.get(key)
+        if isinstance(value, str):
+            return value
+    msg = parsed.get("msg")
+    if isinstance(msg, dict):
+        for key in ("name", "tool", "tool_name", "command"):
+            value = msg.get(key)
+            if isinstance(value, str):
+                return value
+    return event_type
+
+
+def _event_text_payload(parsed: dict) -> str | None:
+    """Extract any final-assistant text from a Codex result event."""
+    for key in ("result", "text", "content", "output"):
+        value = parsed.get(key)
+        if isinstance(value, str):
+            return value
+    msg = parsed.get("msg")
+    if isinstance(msg, dict):
+        for key in ("result", "text", "content", "output"):
+            value = msg.get(key)
+            if isinstance(value, str):
+                return value
+    return None
+
+
+ADAPTERS.append(CodexAdapter())

--- a/src/ralphify/adapters/copilot.py
+++ b/src/ralphify/adapters/copilot.py
@@ -24,7 +24,7 @@ import json
 from pathlib import Path
 
 from ralphify._promise import has_promise_completion
-from ralphify.adapters import ADAPTERS, AdapterEvent, CountsWhat
+from ralphify.adapters import ADAPTERS, AdapterEvent, CacheStats, CountsWhat
 
 
 COPILOT_BINARY_STEM = "copilot"
@@ -56,6 +56,12 @@ class CopilotAdapter:
     # Copilot runs on the blocking path with no stream parsing today; the
     # promise tag must be located somewhere in the captured stdout.
     requires_full_stdout_for_completion: bool = True
+    # Copilot exposes no cache-hit metrics today — its ``--output-format
+    # json`` event schema is loosely documented and carries no usage
+    # payload we can parse reliably.  ``extract_cache_stats`` returns
+    # ``None`` unconditionally; if caching happens server-side, we have
+    # no way to observe it.
+    supports_prompt_caching: bool = False
 
     def matches(self, cmd: list[str]) -> bool:
         if not cmd:
@@ -146,6 +152,11 @@ class CopilotAdapter:
             "Copilot CLI has no hook system as of 2026-04; max_turns "
             "will hard-kill without soft wind-down signal."
         )
+
+    def extract_cache_stats(self, raw: dict) -> CacheStats | None:
+        """No verified usage schema — always ``None``."""
+        del raw
+        return None
 
 
 ADAPTERS.append(CopilotAdapter())

--- a/src/ralphify/adapters/copilot.py
+++ b/src/ralphify/adapters/copilot.py
@@ -1,0 +1,151 @@
+"""GitHub Copilot CLI adapter (alpha).
+
+The standalone ``copilot`` binary (GA 2026-02-25) ships a
+``--output-format json`` mode that is **only loosely documented**.  This
+adapter does best-effort counting based on the empirical shapes seen in
+the ralphify test corpus; unknown event types return ``None`` rather
+than crashing.
+
+Capability matrix:
+
+- ``counts_what = "tool_use"`` with an alpha caveat — counting accuracy
+  depends on ongoing schema discovery (see :file:`docs/agents.md`).
+- ``supports_streaming = False`` — event schema is unverified, so the
+  adapter falls through the blocking path and avoids per-line parsing.
+- ``renders_structured_peek = False`` — peek panel stays in raw-line mode.
+- ``supports_soft_wind_down = False`` — Copilot has no hook system as of
+  2026-04, so ``install_wind_down_hook`` raises :class:`NotImplementedError`
+  (which the engine downgrades to hard-cap-only).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ralphify._promise import has_promise_completion
+from ralphify.adapters import ADAPTERS, AdapterEvent, CountsWhat
+
+
+COPILOT_BINARY_STEM = "copilot"
+"""Binary stem (``Path(cmd[0]).stem``) that identifies the standalone Copilot CLI.
+
+Note: this is the GA ``copilot`` binary, NOT the ``gh copilot`` subcommand.
+The ``gh`` stem is deliberately excluded because ``gh`` hosts many other
+subcommands that have nothing to do with AI agents.
+"""
+
+_OUTPUT_FORMAT_FLAGS: tuple[str, ...] = ("--output-format", "json")
+
+_TOOL_USE_EVENT_TYPES: frozenset[str] = frozenset(
+    {"tool_use", "tool_call", "ToolCall", "ToolUse"}
+)
+_RESULT_EVENT_TYPES: frozenset[str] = frozenset(
+    {"result", "response", "final", "Final", "Complete"}
+)
+
+
+class CopilotAdapter:
+    """Best-effort adapter for the standalone Copilot CLI."""
+
+    name: str = "copilot"
+    counts_what: CountsWhat = "tool_use"
+    supports_streaming: bool = False
+    renders_structured_peek: bool = False
+    supports_soft_wind_down: bool = False
+    # Copilot runs on the blocking path with no stream parsing today; the
+    # promise tag must be located somewhere in the captured stdout.
+    requires_full_stdout_for_completion: bool = True
+
+    def matches(self, cmd: list[str]) -> bool:
+        if not cmd:
+            return False
+        return Path(cmd[0]).stem == COPILOT_BINARY_STEM
+
+    def build_command(self, cmd: list[str]) -> list[str]:
+        """Ensure ``--output-format json`` is present.
+
+        Idempotent: running twice yields the same command. If the caller
+        already supplied ``--output-format <other>``, the existing value is
+        overwritten with ``json`` — we cannot honor a user-chosen format
+        while still emitting a parseable event stream.
+        """
+        result = list(cmd)
+        output_format_flag, output_format_value = _OUTPUT_FORMAT_FLAGS
+        try:
+            format_index = result.index(output_format_flag)
+        except ValueError:
+            result.extend(_OUTPUT_FORMAT_FLAGS)
+        else:
+            value_index = format_index + 1
+            if value_index < len(result):
+                result[value_index] = output_format_value
+            else:
+                result.append(output_format_value)
+        return result
+
+    def parse_event(self, line: str) -> AdapterEvent | None:
+        """Parse best-effort; return ``None`` for unknown shapes.
+
+        The Copilot event schema is ``[unverified]`` in the spec — this
+        method intentionally errs on the side of *not* inventing events
+        so the turn cap is never inflated by false positives.
+        """
+        stripped = line.strip()
+        if not stripped:
+            return None
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError:
+            return None
+        if not isinstance(parsed, dict):
+            return None
+
+        event_type = parsed.get("type") or parsed.get("event") or parsed.get("kind")
+        if not isinstance(event_type, str):
+            return None
+
+        if event_type in _TOOL_USE_EVENT_TYPES:
+            name = parsed.get("name") or parsed.get("tool")
+            return AdapterEvent(
+                kind="tool_use",
+                name=name if isinstance(name, str) else None,
+                raw=parsed,
+            )
+        if event_type in _RESULT_EVENT_TYPES:
+            return AdapterEvent(kind="result", raw=parsed)
+        return None
+
+    def extract_completion_signal(
+        self,
+        *,
+        result_text: str | None,
+        stdout: str | None,
+        user_signal: str,
+    ) -> bool:
+        """Scan the entire stdout for the promise tag.
+
+        Without a verified event schema there is no reliable per-event
+        extraction path; the whole-stdout scan is the safest fallback.
+        *result_text* is unused — Copilot runs on the blocking path and
+        does not produce a streaming result event today.
+        """
+        del result_text
+        if stdout is None:
+            return False
+        return has_promise_completion(stdout, user_signal)
+
+    def install_wind_down_hook(
+        self,
+        tempdir: Path,
+        counter_path: Path,
+        cap: int,
+        grace: int,
+    ) -> dict[str, str]:
+        raise NotImplementedError(
+            "Copilot CLI has no hook system as of 2026-04; max_turns "
+            "will hard-kill without soft wind-down signal."
+        )
+
+
+ADAPTERS.append(CopilotAdapter())

--- a/src/ralphify/cli.py
+++ b/src/ralphify/cli.py
@@ -32,6 +32,8 @@ from ralphify._frontmatter import (
     FIELD_ARGS,
     FIELD_COMMANDS,
     FIELD_CREDIT,
+    FIELD_COMPLETION_SIGNAL,
+    FIELD_STOP_ON_COMPLETION_SIGNAL,
     RALPH_MARKER,
     VALID_NAME_CHARS_MSG,
     parse_frontmatter,
@@ -39,6 +41,7 @@ from ralphify._frontmatter import (
 from ralphify._output import IS_WINDOWS
 from ralphify._run_types import (
     Command,
+    DEFAULT_COMPLETION_SIGNAL,
     DEFAULT_COMMAND_TIMEOUT,
     RunConfig,
     RunState,
@@ -56,13 +59,11 @@ app = typer.Typer()
 
 
 def _exit_error(msg: str) -> NoReturn:
-    """Print an error in red and exit with code 1."""
     _console.print(f"[red]{escape_markup(msg)}[/]")
     raise typer.Exit(1)
 
 
 def _is_nonempty_string(value: Any) -> bool:
-    """Return True if *value* is a non-empty string (after stripping whitespace)."""
     return isinstance(value, str) and bool(value.strip())
 
 
@@ -128,6 +129,10 @@ commands:
     run: git log --oneline -5
 args:
   - focus
+# Optional early exit: uncomment both lines and have the agent emit
+# <promise>COMPLETE</promise> when the task is done.
+# completion_signal: COMPLETE
+# stop_on_completion_signal: true
 ---
 
 You are an autonomous coding agent running in a loop. Each iteration
@@ -146,6 +151,7 @@ starts with a fresh context. Your progress lives in the code and git.
 <!-- Replace this section with your task description -->
 
 - Implement one thing per iteration
+- If you enable promise completion above, emit <promise>COMPLETE</promise> and exit
 - Run tests and fix failures before committing
 - Commit with a descriptive message and push
 """
@@ -202,7 +208,13 @@ def scaffold(
         help="Directory name. If omitted, creates RALPH.md in the current directory.",
     ),
 ) -> None:
-    """Scaffold a new ralph with a ready-to-customize template."""
+    """Scaffold a new ralph with a ready-to-customize template.
+
+    The template includes example commands and args plus an optional
+    completion-signal path you can enable with ``completion_signal`` and
+    ``stop_on_completion_signal`` when the agent should stop early by
+    emitting a matching ``<promise>...</promise>`` tag.
+    """
     if name:
         target_dir = Path.cwd() / name
         target_dir.mkdir(exist_ok=True)
@@ -218,6 +230,13 @@ def scaffold(
     _console.print(f"[green]Created[/] {escape_markup(str(rel))}")
     _console.print(
         f"[dim]Edit the file, then run:[/] ralph run {escape_markup(name or '.')}"
+    )
+    _console.print(
+        "[dim]Optional early exit:[/] uncomment "
+        f"{escape_markup(FIELD_COMPLETION_SIGNAL)} + "
+        f"{escape_markup(FIELD_STOP_ON_COMPLETION_SIGNAL)} "
+        "and emit "
+        f"{escape_markup('<promise>COMPLETE</promise>')}."
     )
 
 
@@ -428,6 +447,36 @@ def _validate_credit(raw_credit: Any) -> bool:
     return raw_credit
 
 
+def _validate_completion_signal(raw_signal: Any) -> str:
+    """Validate the inner ``<promise>...</promise>`` text from frontmatter."""
+    if raw_signal is None:
+        return DEFAULT_COMPLETION_SIGNAL
+    if not _is_nonempty_string(raw_signal):
+        _exit_error(f"'{FIELD_COMPLETION_SIGNAL}' must be a non-empty string.")
+    if raw_signal != raw_signal.strip():
+        _exit_error(
+            f"'{FIELD_COMPLETION_SIGNAL}' must not include leading or trailing whitespace."
+        )
+    if "<" in raw_signal or ">" in raw_signal:
+        _exit_error(
+            f"'{FIELD_COMPLETION_SIGNAL}' must be the text inside "
+            "<promise>...</promise>, not markup or a raw output fragment. "
+            "Example: completion_signal: COMPLETE"
+        )
+    return raw_signal
+
+
+def _validate_stop_on_completion_signal(raw_value: Any) -> bool:
+    """Validate the stop-on-completion-signal frontmatter field."""
+    if raw_value is None:
+        return False
+    if not isinstance(raw_value, bool):
+        _exit_error(
+            f"'{FIELD_STOP_ON_COMPLETION_SIGNAL}' must be true or false, got {raw_value!r}."
+        )
+    return raw_value
+
+
 def _validate_run_options(
     max_iterations: int | None,
     delay: float,
@@ -471,6 +520,10 @@ def _build_run_config(
         ralph_args = _parse_user_args(extra_args, declared_names)
 
     credit = _validate_credit(fm.get(FIELD_CREDIT))
+    completion_signal = _validate_completion_signal(fm.get(FIELD_COMPLETION_SIGNAL))
+    stop_on_completion_signal = _validate_stop_on_completion_signal(
+        fm.get(FIELD_STOP_ON_COMPLETION_SIGNAL)
+    )
 
     return RunConfig(
         agent=agent,
@@ -485,6 +538,8 @@ def _build_run_config(
         log_dir=Path(log_dir) if log_dir else None,
         project_root=Path.cwd(),
         credit=credit,
+        completion_signal=completion_signal,
+        stop_on_completion_signal=stop_on_completion_signal,
     )
 
 
@@ -533,6 +588,10 @@ def run(
     Extra flags (--name value) and positional args after the path are
     passed as user arguments.  Use {{ args.name }} placeholders in
     RALPH.md to reference them.
+
+    To stop before the iteration budget, set ``completion_signal`` and
+    ``stop_on_completion_signal`` in frontmatter and have the agent emit
+    the matching ``<promise>...</promise>`` tag.
 
     Keybindings (interactive terminal):
       p         Toggle live peek of agent output (on by default)

--- a/src/ralphify/engine.py
+++ b/src/ralphify/engine.py
@@ -9,10 +9,12 @@ The loop: run commands → assemble prompt → pipe to agent → repeat.
 
 from __future__ import annotations
 
+import json
 import shlex
 import traceback
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 from ralphify._agent import execute_agent
 from ralphify._events import (
@@ -37,6 +39,7 @@ from ralphify._frontmatter import (
     parse_frontmatter,
 )
 from ralphify._output import format_duration
+from ralphify._promise import has_promise_completion
 from ralphify._run_types import (
     Command,
     RunConfig,
@@ -52,7 +55,6 @@ _RELATIVE_CMD_PREFIX = "./"  # commands starting with this run from the ralph di
 
 
 def _field_hint(field_name: str) -> str:
-    """Return a user-facing hint pointing to a frontmatter field."""
     return f"Check the '{field_name}' field in your {RALPH_MARKER} frontmatter."
 
 
@@ -103,8 +105,6 @@ def _run_commands(
     quoted_args = {k: shlex.quote(v) for k, v in user_args.items()}
     for cmd in commands:
         run_str = resolve_args(cmd.run, quoted_args)
-        # Determine working directory: if the command starts with ./ it's
-        # relative to the ralph directory, otherwise use project root.
         if run_str.lstrip().startswith(_RELATIVE_CMD_PREFIX):
             cwd = ralph_dir
         else:
@@ -167,10 +167,10 @@ def _run_agent_phase(
     config: RunConfig,
     state: RunState,
     emit: BoundEmitter,
-) -> bool:
+) -> tuple[bool, bool]:
     """Run the agent subprocess, update state counters, and emit the result event.
 
-    Returns ``True`` when the agent exited successfully (code 0, no timeout).
+    Returns ``(agent_succeeded, stop_for_completion_signal)``.
     """
     try:
         cmd = shlex.split(config.agent)
@@ -179,12 +179,32 @@ def _run_agent_phase(
             f"Invalid agent command syntax: {config.agent!r}. {_field_hint(FIELD_AGENT)}"
         ) from exc
 
-    # Option C: recheck per-line so mid-iteration peek toggle takes effect.
-    # When neither peek nor logging needs output, pass None so the blocking
-    # path can inherit file descriptors (critical-01 contract).
+    completion_signal = config.completion_signal
+    promise_completed_from_output = False
+    promise_scan_tail = ""
+    promise_scan_limit = max(4096, len(completion_signal) * 4 + 64)
+
+    def _record_promise_fragment(fragment: str) -> None:
+        nonlocal promise_completed_from_output, promise_scan_tail
+        if promise_completed_from_output or not fragment:
+            return
+        promise_scan_tail = (promise_scan_tail + fragment)[-promise_scan_limit:]
+        promise_completed_from_output = has_promise_completion(
+            promise_scan_tail, completion_signal
+        )
+
     def _on_output_line(line: str, stream: OutputStream) -> None:
         if emit.wants_agent_output_lines():
             emit.agent_output_line(line, stream, state.iteration)
+        if stream != "stdout":
+            return
+        stripped = line.strip()
+        if not stripped:
+            return
+        try:
+            json.loads(stripped)
+        except json.JSONDecodeError:
+            _record_promise_fragment(f"{line}\n")
 
     if emit.wants_agent_output_lines() or config.log_dir is not None:
         on_output_line = _on_output_line
@@ -192,17 +212,22 @@ def _run_agent_phase(
         on_output_line = None
 
     try:
+
+        def on_activity(data: dict[str, Any]) -> None:
+            emit(
+                EventType.AGENT_ACTIVITY,
+                AgentActivityData(raw=data, iteration=state.iteration),
+            )
+
         agent = execute_agent(
             cmd,
             prompt,
             timeout=config.timeout,
             log_dir=config.log_dir,
             iteration=state.iteration,
-            on_activity=lambda data: emit(
-                EventType.AGENT_ACTIVITY,
-                AgentActivityData(raw=data, iteration=state.iteration),
-            ),
+            on_activity=on_activity,
             on_output_line=on_output_line,
+            capture_result_text=True,
         )
     except FileNotFoundError as exc:
         raise FileNotFoundError(
@@ -210,6 +235,15 @@ def _run_agent_phase(
         ) from exc
 
     duration = format_duration(agent.elapsed)
+    completion_text = (
+        agent.result_text if agent.result_text is not None else agent.captured_stdout
+    )
+    promise_completed = agent.success and (
+        promise_completed_from_output
+        or has_promise_completion(completion_text, completion_signal)
+    )
+    if promise_completed:
+        state.promise_completed = True
 
     if agent.timed_out:
         state.mark_timed_out()
@@ -218,7 +252,13 @@ def _run_agent_phase(
     elif agent.success:
         state.mark_completed()
         event_type = EventType.ITERATION_COMPLETED
-        state_detail = f"completed ({duration})"
+        if promise_completed:
+            state_detail = (
+                "completed via promise tag "
+                f"<promise>{completion_signal}</promise> ({duration})"
+            )
+        else:
+            state_detail = f"completed ({duration})"
     else:
         state.mark_failed()
         event_type = EventType.ITERATION_FAILED
@@ -233,32 +273,36 @@ def _run_agent_phase(
         log_file=str(agent.log_file) if agent.log_file else None,
         result_text=agent.result_text,
     )
-    # When logging captured output and peek was off (lines were not rendered
-    # live), include captured output so the emitter can echo it after
-    # stopping the Live spinner.  When peek was on, lines were already shown.
-    if not emit.wants_agent_output_lines() and config.log_dir is not None:
-        ended_data["echo_stdout"] = agent.captured_stdout
-        ended_data["echo_stderr"] = agent.captured_stderr
+    if not emit.wants_agent_output_lines():
+        # When peek was off, echo any captured raw output after the spinner
+        # stops so blocking agents do not appear silent. Structured agents
+        # already surface their parsed result_text, so avoid echoing raw JSON
+        # unless we explicitly captured logs.
+        if config.log_dir is not None:
+            ended_data["echo_stdout"] = agent.captured_stdout
+            ended_data["echo_stderr"] = agent.captured_stderr
+        elif agent.result_text is None and agent.captured_stdout is not None:
+            ended_data["echo_stdout"] = agent.captured_stdout
 
     emit(event_type, ended_data)
-    return agent.success
+    return agent.success, promise_completed and config.stop_on_completion_signal
 
 
 def _run_iteration(
     config: RunConfig,
     state: RunState,
     emit: BoundEmitter,
-) -> bool:
+) -> tuple[bool, bool]:
     """Execute one iteration of the agent loop.
 
-    Returns ``True`` if the loop should continue, ``False`` when
-    ``--stop-on-error`` triggers.
+    Returns (should_continue, stop_for_completion_signal):
+      - should_continue: True if the loop should continue, False to break
+      - stop_for_completion_signal: True if a completion signal ended the run early
     """
     iteration = state.iteration
 
     emit(EventType.ITERATION_STARTED, IterationStartedData(iteration=iteration))
 
-    # Run commands and collect outputs for placeholder resolution
     command_outputs: dict[str, str] = {}
     if config.commands:
         emit(
@@ -279,22 +323,22 @@ def _run_iteration(
             ),
         )
 
-    # Assemble prompt
     prompt = _assemble_prompt(config, state, command_outputs)
     emit(
         EventType.PROMPT_ASSEMBLED,
         PromptAssembledData(iteration=iteration, prompt_length=len(prompt)),
     )
 
-    # Run agent
-    agent_succeeded = _run_agent_phase(prompt, config, state, emit)
+    agent_succeeded, stop_for_completion_signal = _run_agent_phase(
+        prompt, config, state, emit
+    )
 
     if not agent_succeeded and config.stop_on_error:
         state.status = RunStatus.FAILED
         emit.log_error("Stopping due to --stop-on-error.")
-        return False
+        return False, stop_for_completion_signal
 
-    return True
+    return True, stop_for_completion_signal
 
 
 def _delay_if_needed(config: RunConfig, state: RunState, emit: BoundEmitter) -> None:
@@ -346,14 +390,19 @@ def run_loop(
             if not _handle_control_signals(state, emit):
                 break
 
-            state.iteration += 1
             if (
                 config.max_iterations is not None
-                and state.iteration > config.max_iterations
+                and state.iteration >= config.max_iterations
             ):
                 break
+            state.iteration += 1
 
-            should_continue = _run_iteration(config, state, emit)
+            should_continue, stop_for_completion_signal = _run_iteration(
+                config, state, emit
+            )
+            if stop_for_completion_signal:
+                state.status = RunStatus.COMPLETED
+                break
             if not should_continue:
                 break
 

--- a/src/ralphify/engine.py
+++ b/src/ralphify/engine.py
@@ -9,7 +9,6 @@ The loop: run commands → assemble prompt → pipe to agent → repeat.
 
 from __future__ import annotations
 
-import json
 import shlex
 import traceback
 from datetime import datetime, timezone
@@ -39,7 +38,6 @@ from ralphify._frontmatter import (
     parse_frontmatter,
 )
 from ralphify._output import format_duration
-from ralphify._promise import has_promise_completion
 from ralphify._run_types import (
     Command,
     RunConfig,
@@ -48,6 +46,7 @@ from ralphify._run_types import (
 )
 from ralphify._resolver import resolve_all, resolve_args
 from ralphify._runner import run_command
+from ralphify.adapters import select_adapter
 
 
 _PAUSE_POLL_INTERVAL = 0.25  # seconds between pause/resume checks
@@ -179,37 +178,27 @@ def _run_agent_phase(
             f"Invalid agent command syntax: {config.agent!r}. {_field_hint(FIELD_AGENT)}"
         ) from exc
 
+    adapter = select_adapter(cmd)
     completion_signal = config.completion_signal
-    promise_completed_from_output = False
-    promise_scan_tail = ""
-    promise_scan_limit = max(4096, len(completion_signal) * 4 + 64)
-
-    def _record_promise_fragment(fragment: str) -> None:
-        nonlocal promise_completed_from_output, promise_scan_tail
-        if promise_completed_from_output or not fragment:
-            return
-        promise_scan_tail = (promise_scan_tail + fragment)[-promise_scan_limit:]
-        promise_completed_from_output = has_promise_completion(
-            promise_scan_tail, completion_signal
-        )
 
     def _on_output_line(line: str, stream: OutputStream) -> None:
         if emit.wants_agent_output_lines():
             emit.agent_output_line(line, stream, state.iteration)
-        if stream != "stdout":
-            return
-        stripped = line.strip()
-        if not stripped:
-            return
-        try:
-            json.loads(stripped)
-        except json.JSONDecodeError:
-            _record_promise_fragment(f"{line}\n")
 
     if emit.wants_agent_output_lines() or config.log_dir is not None:
         on_output_line = _on_output_line
     else:
         on_output_line = None
+
+    # Capture full stdout only when somebody downstream actually needs the
+    # bytes — log writing, or promise detection for adapters that cannot
+    # work from ``agent.result_text`` alone.  Without this gate every
+    # iteration would buffer the entire transcript even for verbose
+    # streaming agents, regressing memory vs the prior tail-scan path.
+    capture_stdout_for_promise = (
+        config.stop_on_completion_signal and adapter.requires_full_stdout_for_completion
+    )
+    capture_stdout = config.log_dir is not None or capture_stdout_for_promise
 
     try:
 
@@ -225,9 +214,11 @@ def _run_agent_phase(
             timeout=config.timeout,
             log_dir=config.log_dir,
             iteration=state.iteration,
+            adapter=adapter,
             on_activity=on_activity,
             on_output_line=on_output_line,
             capture_result_text=True,
+            capture_stdout=capture_stdout,
         )
     except FileNotFoundError as exc:
         raise FileNotFoundError(
@@ -235,12 +226,10 @@ def _run_agent_phase(
         ) from exc
 
     duration = format_duration(agent.elapsed)
-    completion_text = (
-        agent.result_text if agent.result_text is not None else agent.captured_stdout
-    )
-    promise_completed = agent.success and (
-        promise_completed_from_output
-        or has_promise_completion(completion_text, completion_signal)
+    promise_completed = agent.success and adapter.extract_completion_signal(
+        result_text=agent.result_text,
+        stdout=agent.captured_stdout,
+        user_signal=completion_signal,
     )
     if promise_completed:
         state.promise_completed = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,8 +2,17 @@
 
 import pytest
 
+from ralphify.adapters import ADAPTERS
+
 
 @pytest.fixture(autouse=True)
 def _disable_streaming(monkeypatch):
-    """Disable the Popen-based streaming path in all tests."""
-    monkeypatch.setattr("ralphify._agent._supports_stream_json", lambda cmd: False)
+    """Force the blocking path and raw peek on every registered adapter.
+
+    Tests that explicitly need the Popen streaming path or structured
+    peek rendering re-enable the relevant flag on the specific adapter
+    they exercise.
+    """
+    for adapter in ADAPTERS:
+        monkeypatch.setattr(adapter, "supports_streaming", False)
+        monkeypatch.setattr(adapter, "renders_structured_peek", False)

--- a/tests/test_adapters_claude.py
+++ b/tests/test_adapters_claude.py
@@ -175,6 +175,94 @@ def test_capability_flags() -> None:
     assert adapter.renders_structured_peek is True
     assert adapter.supports_soft_wind_down is True
     assert adapter.requires_full_stdout_for_completion is False
+    assert adapter.supports_prompt_caching is True
+
+
+def test_extract_cache_stats_from_assistant_usage() -> None:
+    adapter = ClaudeAdapter()
+    raw = {
+        "type": "assistant",
+        "message": {
+            "content": [],
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 2000,
+                "cache_read_input_tokens": 8000,
+            },
+        },
+    }
+    stats = adapter.extract_cache_stats(raw)
+    assert stats is not None
+    assert stats.read_tokens == 8000
+    assert stats.write_tokens == 2000
+    assert stats.uncached_tokens == 100
+
+
+def test_extract_cache_stats_from_result_event_top_level_usage() -> None:
+    """Claude's terminal result event carries usage at the top level."""
+    adapter = ClaudeAdapter()
+    raw = {
+        "type": "result",
+        "result": "done",
+        "usage": {
+            "input_tokens": 5,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 12345,
+        },
+    }
+    stats = adapter.extract_cache_stats(raw)
+    assert stats is not None
+    assert stats.read_tokens == 12345
+    assert stats.write_tokens == 0
+    assert stats.uncached_tokens == 5
+
+
+def test_extract_cache_stats_returns_none_when_no_usage() -> None:
+    adapter = ClaudeAdapter()
+    assert adapter.extract_cache_stats({"type": "assistant"}) is None
+    assert (
+        adapter.extract_cache_stats({"type": "assistant", "message": {"content": []}})
+        is None
+    )
+
+
+def test_extract_cache_stats_returns_none_when_all_counts_zero() -> None:
+    """An empty usage object is indistinguishable from no-data; return None."""
+    adapter = ClaudeAdapter()
+    raw = {
+        "type": "assistant",
+        "message": {"usage": {"input_tokens": 0}},
+    }
+    assert adapter.extract_cache_stats(raw) is None
+
+
+def test_extract_cache_stats_treats_missing_fields_as_zero() -> None:
+    """Older Claude API responses may omit cache_* fields entirely."""
+    adapter = ClaudeAdapter()
+    raw = {
+        "type": "assistant",
+        "message": {"usage": {"input_tokens": 42}},
+    }
+    stats = adapter.extract_cache_stats(raw)
+    assert stats is not None
+    assert stats.read_tokens == 0
+    assert stats.write_tokens == 0
+    assert stats.uncached_tokens == 42
+
+
+def test_extract_cache_stats_defensive_on_malformed_shapes() -> None:
+    adapter = ClaudeAdapter()
+    assert adapter.extract_cache_stats({"usage": "not a dict"}) is None
+    assert adapter.extract_cache_stats({"message": "not a dict"}) is None
+    assert (
+        adapter.extract_cache_stats(
+            {"usage": {"input_tokens": "twelve", "cache_read_input_tokens": None}}
+        )
+        is None
+    )
+    # Booleans must not leak through as 1/0 — they are not real counts.
+    assert adapter.extract_cache_stats({"usage": {"input_tokens": True}}) is None
 
 
 def test_registered_in_adapters_registry() -> None:

--- a/tests/test_adapters_claude.py
+++ b/tests/test_adapters_claude.py
@@ -1,0 +1,183 @@
+"""Tests for the Claude stream-json adapter."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ralphify.adapters import select_adapter
+from ralphify.adapters.claude import ClaudeAdapter
+
+
+def _assistant_event(*blocks: dict) -> str:
+    """Build one JSON line matching Claude's assistant message schema."""
+    return json.dumps(
+        {
+            "type": "assistant",
+            "message": {"content": list(blocks)},
+        }
+    )
+
+
+def _result_event(result_text: str) -> str:
+    return json.dumps({"type": "result", "result": result_text})
+
+
+def test_matches_claude_binary_stem() -> None:
+    adapter = ClaudeAdapter()
+    assert adapter.matches(["claude"]) is True
+    assert adapter.matches(["/usr/local/bin/claude"]) is True
+    assert adapter.matches(["claude", "--print"]) is True
+    assert adapter.matches(["codex"]) is False
+    assert adapter.matches([]) is False
+
+
+def test_build_command_appends_stream_flags() -> None:
+    adapter = ClaudeAdapter()
+    result = adapter.build_command(["claude"])
+    assert result == ["claude", "--output-format", "stream-json", "--verbose"]
+
+
+def test_build_command_is_idempotent() -> None:
+    adapter = ClaudeAdapter()
+    once = adapter.build_command(["claude"])
+    twice = adapter.build_command(once)
+    assert once == twice
+
+
+def test_build_command_preserves_user_flags() -> None:
+    adapter = ClaudeAdapter()
+    result = adapter.build_command(["claude", "--print", "-p"])
+    assert result[:3] == ["claude", "--print", "-p"]
+    assert "--output-format" in result
+    assert "stream-json" in result
+
+
+def test_parse_tool_use_event() -> None:
+    adapter = ClaudeAdapter()
+    line = _assistant_event({"type": "tool_use", "name": "Bash", "input": {}})
+    event = adapter.parse_event(line)
+    assert event is not None
+    assert event.kind == "tool_use"
+    assert event.name == "Bash"
+
+
+def test_parse_result_event() -> None:
+    adapter = ClaudeAdapter()
+    event = adapter.parse_event(_result_event("done"))
+    assert event is not None
+    assert event.kind == "result"
+
+
+def test_parse_ignores_thinking_blocks() -> None:
+    adapter = ClaudeAdapter()
+    line = _assistant_event({"type": "thinking", "thinking": "planning..."})
+    event = adapter.parse_event(line)
+    assert event is not None
+    assert event.kind == "message"
+
+
+def test_parse_malformed_json_returns_none() -> None:
+    adapter = ClaudeAdapter()
+    assert adapter.parse_event("not json") is None
+    assert adapter.parse_event("") is None
+    assert adapter.parse_event("   \n") is None
+
+
+def test_parse_non_dict_json_returns_none() -> None:
+    adapter = ClaudeAdapter()
+    assert adapter.parse_event("[1, 2, 3]") is None
+    assert adapter.parse_event('"just a string"') is None
+
+
+def test_parse_tool_use_with_non_string_name() -> None:
+    """Defensive: tool_use blocks with missing name must not raise."""
+    adapter = ClaudeAdapter()
+    line = _assistant_event({"type": "tool_use", "input": {}})
+    event = adapter.parse_event(line)
+    assert event is not None
+    assert event.kind == "tool_use"
+    assert event.name is None
+
+
+def test_parse_skips_first_non_tool_use_block() -> None:
+    adapter = ClaudeAdapter()
+    line = _assistant_event(
+        {"type": "text", "text": "thinking out loud"},
+        {"type": "tool_use", "name": "Edit", "input": {}},
+    )
+    event = adapter.parse_event(line)
+    assert event is not None
+    assert event.kind == "tool_use"
+    assert event.name == "Edit"
+
+
+def test_extract_completion_signal_from_result_text() -> None:
+    adapter = ClaudeAdapter()
+    result_text = "<promise>DONE</promise>"
+    assert (
+        adapter.extract_completion_signal(
+            result_text=result_text, stdout=None, user_signal="DONE"
+        )
+        is True
+    )
+    assert (
+        adapter.extract_completion_signal(
+            result_text=result_text, stdout=None, user_signal="OTHER"
+        )
+        is False
+    )
+
+
+def test_extract_completion_signal_ignores_raw_stdout() -> None:
+    """ClaudeAdapter only inspects ``result_text``; the streaming reader
+    extracts the terminal assistant message there.  Promise tags embedded
+    in raw stdout (e.g. ``status`` or ``assistant`` JSON) must not trigger
+    completion."""
+    adapter = ClaudeAdapter()
+    stdout = "raw text <promise>MARKER</promise> trailing"
+    assert (
+        adapter.extract_completion_signal(
+            result_text=None, stdout=stdout, user_signal="MARKER"
+        )
+        is False
+    )
+
+
+def test_extract_completion_signal_handles_missing_result_text() -> None:
+    adapter = ClaudeAdapter()
+    assert (
+        adapter.extract_completion_signal(
+            result_text=None, stdout=None, user_signal="DONE"
+        )
+        is False
+    )
+    assert (
+        adapter.extract_completion_signal(
+            result_text="", stdout=None, user_signal="DONE"
+        )
+        is False
+    )
+
+
+def test_install_wind_down_hook_raises_not_implemented(tmp_path) -> None:
+    adapter = ClaudeAdapter()
+    with pytest.raises(NotImplementedError):
+        adapter.install_wind_down_hook(tmp_path, tmp_path / "counter", 10, 2)
+
+
+def test_capability_flags() -> None:
+    adapter = ClaudeAdapter()
+    assert adapter.name == "claude"
+    assert adapter.counts_what == "tool_use"
+    assert adapter.supports_streaming is True
+    assert adapter.renders_structured_peek is True
+    assert adapter.supports_soft_wind_down is True
+    assert adapter.requires_full_stdout_for_completion is False
+
+
+def test_registered_in_adapters_registry() -> None:
+    """Import side-effect registration should hand back the Claude adapter."""
+    selected = select_adapter(["claude"])
+    assert isinstance(selected, ClaudeAdapter)

--- a/tests/test_adapters_codex.py
+++ b/tests/test_adapters_codex.py
@@ -152,6 +152,97 @@ def test_capability_flags() -> None:
     assert adapter.renders_structured_peek is False
     assert adapter.supports_soft_wind_down is True
     assert adapter.requires_full_stdout_for_completion is True
+    assert adapter.supports_prompt_caching is True
+
+
+def test_extract_cache_stats_responses_api_shape() -> None:
+    """Responses API emits input_tokens_details.cached_tokens."""
+    adapter = CodexAdapter()
+    raw = {
+        "type": "TokenCount",
+        "usage": {
+            "input_tokens": 10_000,
+            "output_tokens": 300,
+            "input_tokens_details": {"cached_tokens": 7500},
+        },
+    }
+    stats = adapter.extract_cache_stats(raw)
+    assert stats is not None
+    assert stats.read_tokens == 7500
+    assert stats.write_tokens == 0  # OpenAI does not split write vs miss
+    assert stats.uncached_tokens == 2500
+
+
+def test_extract_cache_stats_legacy_chat_shape() -> None:
+    """Older Codex builds emit prompt_tokens + prompt_tokens_details."""
+    adapter = CodexAdapter()
+    raw = {
+        "usage": {
+            "prompt_tokens": 1000,
+            "prompt_tokens_details": {"cached_tokens": 400},
+        },
+    }
+    stats = adapter.extract_cache_stats(raw)
+    assert stats is not None
+    assert stats.read_tokens == 400
+    assert stats.uncached_tokens == 600
+
+
+def test_extract_cache_stats_usage_nested_under_msg() -> None:
+    """Some Codex events wrap usage under ``msg.usage``."""
+    adapter = CodexAdapter()
+    raw = {
+        "type": "TurnCompleted",
+        "msg": {
+            "usage": {
+                "input_tokens": 500,
+                "input_tokens_details": {"cached_tokens": 500},
+            },
+        },
+    }
+    stats = adapter.extract_cache_stats(raw)
+    assert stats is not None
+    assert stats.read_tokens == 500
+    assert stats.uncached_tokens == 0
+
+
+def test_extract_cache_stats_returns_none_when_no_usage() -> None:
+    adapter = CodexAdapter()
+    assert adapter.extract_cache_stats({"type": "TurnStarted"}) is None
+    assert (
+        adapter.extract_cache_stats({"type": "CommandExecution", "command": "ls"})
+        is None
+    )
+
+
+def test_extract_cache_stats_returns_none_on_empty_usage() -> None:
+    adapter = CodexAdapter()
+    assert adapter.extract_cache_stats({"usage": {}}) is None
+    assert adapter.extract_cache_stats({"usage": {"input_tokens": 0}}) is None
+
+
+def test_extract_cache_stats_clamps_negative_uncached_to_zero() -> None:
+    """If cached_tokens exceeds input_tokens (shouldn't happen but defensive)."""
+    adapter = CodexAdapter()
+    raw = {
+        "usage": {
+            "input_tokens": 100,
+            "input_tokens_details": {"cached_tokens": 500},
+        },
+    }
+    stats = adapter.extract_cache_stats(raw)
+    assert stats is not None
+    assert stats.uncached_tokens == 0
+
+
+def test_extract_cache_stats_defensive_on_malformed_shapes() -> None:
+    adapter = CodexAdapter()
+    assert adapter.extract_cache_stats({"usage": "not a dict"}) is None
+    assert adapter.extract_cache_stats({"msg": "not a dict"}) is None
+    assert (
+        adapter.extract_cache_stats({"usage": {"input_tokens_details": "not dict"}})
+        is None
+    )
 
 
 def test_registered_in_adapters_registry() -> None:

--- a/tests/test_adapters_codex.py
+++ b/tests/test_adapters_codex.py
@@ -1,0 +1,159 @@
+"""Tests for the Codex CLI adapter."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ralphify.adapters import select_adapter
+from ralphify.adapters.codex import CodexAdapter
+
+
+def test_matches_codex_binary_stem() -> None:
+    adapter = CodexAdapter()
+    assert adapter.matches(["codex"]) is True
+    assert adapter.matches(["/usr/local/bin/codex"]) is True
+    assert adapter.matches(["codex", "exec", "--sandbox"]) is True
+    assert adapter.matches(["claude"]) is False
+    assert adapter.matches([]) is False
+
+
+def test_build_command_appends_json_flag() -> None:
+    adapter = CodexAdapter()
+    assert adapter.build_command(["codex"]) == ["codex", "--json"]
+
+
+def test_build_command_is_idempotent() -> None:
+    adapter = CodexAdapter()
+    once = adapter.build_command(["codex"])
+    twice = adapter.build_command(once)
+    assert once == twice
+
+
+def test_parse_tool_call_events() -> None:
+    adapter = CodexAdapter()
+    for event_type, expected_name in [
+        ("CollabToolCall", "Edit"),
+        ("McpToolCall", "Edit"),
+        ("CommandExecution", "Edit"),
+    ]:
+        line = json.dumps({"type": event_type, "name": "Edit"})
+        event = adapter.parse_event(line)
+        assert event is not None
+        assert event.kind == "tool_use"
+        assert event.name == expected_name
+
+
+def test_parse_turn_events() -> None:
+    adapter = CodexAdapter()
+    for event_type in ("TurnStarted", "TurnCompleted"):
+        # TurnCompleted is a result *and* turn event; result wins.
+        line = json.dumps({"type": event_type})
+        event = adapter.parse_event(line)
+        assert event is not None
+        if event_type == "TurnCompleted":
+            assert event.kind == "result"
+        else:
+            assert event.kind == "turn"
+
+
+def test_parse_unknown_events_become_message() -> None:
+    adapter = CodexAdapter()
+    event = adapter.parse_event(json.dumps({"type": "SomethingNew"}))
+    assert event is not None
+    assert event.kind == "message"
+
+
+def test_parse_malformed_returns_none() -> None:
+    adapter = CodexAdapter()
+    assert adapter.parse_event("not json") is None
+    assert adapter.parse_event("") is None
+    assert adapter.parse_event("42") is None
+
+
+def test_parse_tool_call_nested_under_msg() -> None:
+    """Some Codex builds wrap event data under a ``msg`` key."""
+    adapter = CodexAdapter()
+    line = json.dumps({"msg": {"type": "CommandExecution", "command": "git status"}})
+    event = adapter.parse_event(line)
+    assert event is not None
+    assert event.kind == "tool_use"
+    assert event.name == "git status"
+
+
+def test_parse_falls_back_to_event_type_for_name() -> None:
+    adapter = CodexAdapter()
+    line = json.dumps({"type": "CollabToolCall"})
+    event = adapter.parse_event(line)
+    assert event is not None
+    assert event.name == "CollabToolCall"
+
+
+def test_extract_completion_signal_from_stream() -> None:
+    adapter = CodexAdapter()
+    stream = "\n".join(
+        [
+            json.dumps({"type": "TurnStarted"}),
+            json.dumps({"type": "CommandExecution", "command": "ls"}),
+            json.dumps({"type": "TaskComplete", "text": "<promise>DONE</promise>"}),
+        ]
+    )
+    assert (
+        adapter.extract_completion_signal(
+            result_text=None, stdout=stream, user_signal="DONE"
+        )
+        is True
+    )
+    assert (
+        adapter.extract_completion_signal(
+            result_text=None, stdout=stream, user_signal="OTHER"
+        )
+        is False
+    )
+
+
+def test_extract_completion_signal_scans_plain_output() -> None:
+    adapter = CodexAdapter()
+    assert (
+        adapter.extract_completion_signal(
+            result_text=None,
+            stdout="some <promise>HI</promise> text",
+            user_signal="HI",
+        )
+        is True
+    )
+
+
+def test_extract_completion_signal_returns_false_when_stdout_missing() -> None:
+    """When the engine elects not to capture stdout, Codex cannot detect
+    completion — the streaming reader does not populate ``result_text``
+    for Codex's ``TaskComplete`` event shape."""
+    adapter = CodexAdapter()
+    assert (
+        adapter.extract_completion_signal(
+            result_text=None, stdout=None, user_signal="DONE"
+        )
+        is False
+    )
+
+
+def test_install_wind_down_hook_raises_not_implemented(tmp_path) -> None:
+    adapter = CodexAdapter()
+    with pytest.raises(NotImplementedError):
+        adapter.install_wind_down_hook(tmp_path, tmp_path / "counter", 10, 2)
+
+
+def test_capability_flags() -> None:
+    adapter = CodexAdapter()
+    assert adapter.name == "codex"
+    assert adapter.counts_what == "tool_use"
+    assert adapter.supports_streaming is True
+    assert adapter.renders_structured_peek is False
+    assert adapter.supports_soft_wind_down is True
+    assert adapter.requires_full_stdout_for_completion is True
+
+
+def test_registered_in_adapters_registry() -> None:
+    selected = select_adapter(["codex"])
+    assert isinstance(selected, CodexAdapter)

--- a/tests/test_adapters_copilot.py
+++ b/tests/test_adapters_copilot.py
@@ -1,0 +1,129 @@
+"""Tests for the Copilot CLI adapter (alpha)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from ralphify.adapters import select_adapter
+from ralphify.adapters.copilot import CopilotAdapter
+
+
+def test_matches_copilot_binary_stem() -> None:
+    adapter = CopilotAdapter()
+    assert adapter.matches(["copilot"]) is True
+    assert adapter.matches(["/opt/copilot/bin/copilot"]) is True
+    # Deliberately does NOT match the gh subcommand
+    assert adapter.matches(["gh"]) is False
+    assert adapter.matches([]) is False
+
+
+def test_build_command_appends_json_flags() -> None:
+    adapter = CopilotAdapter()
+    assert adapter.build_command(["copilot"]) == [
+        "copilot",
+        "--output-format",
+        "json",
+    ]
+
+
+def test_build_command_is_idempotent() -> None:
+    adapter = CopilotAdapter()
+    once = adapter.build_command(["copilot"])
+    twice = adapter.build_command(once)
+    assert once == twice
+
+
+def test_parse_tool_use_variants() -> None:
+    adapter = CopilotAdapter()
+    for event_type in ("tool_use", "tool_call", "ToolCall", "ToolUse"):
+        line = json.dumps({"type": event_type, "name": "Edit"})
+        event = adapter.parse_event(line)
+        assert event is not None
+        assert event.kind == "tool_use"
+        assert event.name == "Edit"
+
+
+def test_parse_result_variants() -> None:
+    adapter = CopilotAdapter()
+    for event_type in ("result", "response", "final", "Complete"):
+        event = adapter.parse_event(json.dumps({"type": event_type}))
+        assert event is not None
+        assert event.kind == "result"
+
+
+def test_parse_unknown_returns_none() -> None:
+    """Unknown event types must NOT count against the turn cap."""
+    adapter = CopilotAdapter()
+    assert adapter.parse_event(json.dumps({"type": "SomethingElse"})) is None
+    assert adapter.parse_event(json.dumps({"type": "progress"})) is None
+
+
+def test_parse_missing_type_returns_none() -> None:
+    adapter = CopilotAdapter()
+    assert adapter.parse_event(json.dumps({"name": "Edit"})) is None
+
+
+def test_parse_malformed_returns_none() -> None:
+    adapter = CopilotAdapter()
+    assert adapter.parse_event("not json") is None
+    assert adapter.parse_event("") is None
+
+
+def test_parse_event_with_alternate_key_names() -> None:
+    """Covers ``event`` / ``kind`` alternative type keys."""
+    adapter = CopilotAdapter()
+    event = adapter.parse_event(json.dumps({"event": "tool_use", "name": "Bash"}))
+    assert event is not None
+    assert event.kind == "tool_use"
+    assert event.name == "Bash"
+
+
+def test_extract_completion_signal_scans_stdout() -> None:
+    adapter = CopilotAdapter()
+    assert (
+        adapter.extract_completion_signal(
+            result_text=None,
+            stdout="chat chatter <promise>MARKER</promise> more text",
+            user_signal="MARKER",
+        )
+        is True
+    )
+    assert (
+        adapter.extract_completion_signal(
+            result_text=None, stdout="no marker here", user_signal="MARKER"
+        )
+        is False
+    )
+
+
+def test_extract_completion_signal_returns_false_when_stdout_missing() -> None:
+    adapter = CopilotAdapter()
+    assert (
+        adapter.extract_completion_signal(
+            result_text=None, stdout=None, user_signal="MARKER"
+        )
+        is False
+    )
+
+
+def test_install_wind_down_hook_raises_not_implemented(tmp_path) -> None:
+    adapter = CopilotAdapter()
+    with pytest.raises(NotImplementedError, match="no hook system"):
+        adapter.install_wind_down_hook(tmp_path, tmp_path / "counter", 10, 2)
+
+
+def test_capability_flags() -> None:
+    adapter = CopilotAdapter()
+    assert adapter.name == "copilot"
+    assert adapter.counts_what == "tool_use"
+    assert adapter.supports_streaming is False
+    assert adapter.renders_structured_peek is False
+    assert adapter.supports_soft_wind_down is False
+    assert adapter.requires_full_stdout_for_completion is True
+
+
+def test_registered_in_adapters_registry() -> None:
+    selected = select_adapter(["copilot"])
+    assert isinstance(selected, CopilotAdapter)

--- a/tests/test_adapters_copilot.py
+++ b/tests/test_adapters_copilot.py
@@ -122,6 +122,19 @@ def test_capability_flags() -> None:
     assert adapter.renders_structured_peek is False
     assert adapter.supports_soft_wind_down is False
     assert adapter.requires_full_stdout_for_completion is True
+    assert adapter.supports_prompt_caching is False
+
+
+def test_extract_cache_stats_always_returns_none() -> None:
+    """Copilot exposes no verified usage schema; never claim cache stats."""
+    adapter = CopilotAdapter()
+    assert adapter.extract_cache_stats({}) is None
+    assert (
+        adapter.extract_cache_stats(
+            {"usage": {"input_tokens": 1000, "cached_tokens": 500}}
+        )
+        is None
+    )
 
 
 def test_registered_in_adapters_registry() -> None:

--- a/tests/test_adapters_registry.py
+++ b/tests/test_adapters_registry.py
@@ -41,3 +41,10 @@ def test_all_adapters_satisfy_protocol() -> None:
     """Runtime Protocol check catches shape regressions in any adapter."""
     for adapter in ADAPTERS:
         assert isinstance(adapter, CLIAdapter)
+
+
+def test_generic_adapter_has_no_cache_support() -> None:
+    generic = GenericAdapter()
+    assert generic.supports_prompt_caching is False
+    assert generic.extract_cache_stats({}) is None
+    assert generic.extract_cache_stats({"usage": {"input_tokens": 100}}) is None

--- a/tests/test_adapters_registry.py
+++ b/tests/test_adapters_registry.py
@@ -1,0 +1,43 @@
+"""Tests for the adapter registry and first-match dispatch."""
+
+from __future__ import annotations
+
+from ralphify.adapters import ADAPTERS, CLIAdapter, select_adapter
+from ralphify.adapters._generic import GenericAdapter
+from ralphify.adapters.claude import ClaudeAdapter
+from ralphify.adapters.codex import CodexAdapter
+from ralphify.adapters.copilot import CopilotAdapter
+
+
+def test_registry_contains_builtin_adapters() -> None:
+    types = {type(a) for a in ADAPTERS}
+    assert ClaudeAdapter in types
+    assert CodexAdapter in types
+    assert CopilotAdapter in types
+
+
+def test_select_adapter_dispatches_by_binary_stem() -> None:
+    assert isinstance(select_adapter(["claude"]), ClaudeAdapter)
+    assert isinstance(select_adapter(["codex", "exec"]), CodexAdapter)
+    assert isinstance(select_adapter(["copilot"]), CopilotAdapter)
+
+
+def test_select_adapter_falls_back_to_generic() -> None:
+    selected = select_adapter(["aider", "--model", "claude-4"])
+    assert isinstance(selected, GenericAdapter)
+
+
+def test_select_adapter_handles_empty_cmd() -> None:
+    assert isinstance(select_adapter([]), GenericAdapter)
+
+
+def test_generic_adapter_parse_never_raises() -> None:
+    generic = GenericAdapter()
+    assert generic.parse_event("garbage") is None
+    assert generic.parse_event("") is None
+
+
+def test_all_adapters_satisfy_protocol() -> None:
+    """Runtime Protocol check catches shape regressions in any adapter."""
+    for adapter in ADAPTERS:
+        assert isinstance(adapter, CLIAdapter)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -365,6 +365,32 @@ class TestExecuteAgentBlocking:
         assert result.captured_stdout == "partial stdout"
         assert result.captured_stderr == "partial stderr"
 
+    @patch(MOCK_SUBPROCESS)
+    def test_capture_result_text_does_not_buffer_blocking_output_without_log_dir(
+        self, mock_popen
+    ):
+        mock_popen.return_value = ok_proc(
+            stdout_text="<promise>done</promise>\n",
+            stderr_text="some stderr\n",
+        )
+        result = _run_agent_blocking(
+            ["echo"],
+            "prompt",
+            timeout=None,
+            log_dir=None,
+            iteration=1,
+            capture_result_text=True,
+        )
+
+        assert result.captured_stdout is None
+        assert result.captured_stderr is None
+        assert result.result_text is None
+
+        call_kwargs = mock_popen.call_args[1]
+        assert call_kwargs.get("stdin") == subprocess.PIPE
+        assert call_kwargs.get("stdout") == subprocess.PIPE
+        assert call_kwargs.get("stderr") is None
+
     @patch(MOCK_SUBPROCESS, side_effect=ok_proc)
     def test_no_log_when_dir_not_set(self, mock_popen):
         result = execute_agent(
@@ -400,19 +426,22 @@ class TestAgentResult:
         assert result.timed_out is True
         assert result.returncode is None
 
-    def test_success_when_zero_exit(self):
-        result = AgentResult(returncode=0, elapsed=1.0, log_file=None)
-        assert result.success is True
-
-    def test_not_success_when_nonzero_exit(self):
-        result = AgentResult(returncode=1, elapsed=1.0, log_file=None)
-        assert result.success is False
-
-    def test_not_success_when_timed_out(self):
-        result = AgentResult(
-            returncode=None, elapsed=5.0, log_file=None, timed_out=True
-        )
-        assert result.success is False
+    @pytest.mark.parametrize(
+        ("result", "expected"),
+        [
+            (AgentResult(returncode=0, elapsed=1.0, log_file=None), True),
+            (AgentResult(returncode=1, elapsed=1.0, log_file=None), False),
+            (
+                AgentResult(
+                    returncode=None, elapsed=5.0, log_file=None, timed_out=True
+                ),
+                False,
+            ),
+        ],
+        ids=["zero-exit", "nonzero-exit", "timed-out"],
+    )
+    def test_success(self, result, expected):
+        assert result.success is expected
 
 
 class TestExecuteAgentDispatch:
@@ -438,9 +467,143 @@ class TestExecuteAgentDispatch:
         assert result.result_text == "done"
         mock_popen.assert_called_once()
 
+    def test_execute_agent_passes_capture_result_text_to_streaming_helper(
+        self, monkeypatch
+    ):
+        on_activity = MagicMock()
+        on_output_line = MagicMock()
+        fake_streaming = MagicMock(return_value=AgentResult(returncode=0, elapsed=0.01))
+
+        monkeypatch.setattr("ralphify._agent._supports_stream_json", lambda cmd: True)
+        monkeypatch.setattr("ralphify._agent._run_agent_streaming", fake_streaming)
+
+        execute_agent(
+            ["claude", "-p"],
+            "prompt",
+            timeout=None,
+            log_dir=None,
+            iteration=1,
+            on_activity=on_activity,
+            on_output_line=on_output_line,
+            capture_result_text=True,
+        )
+
+        fake_streaming.assert_called_once_with(
+            ["claude", "-p"],
+            "prompt",
+            None,
+            None,
+            1,
+            on_activity=on_activity,
+            on_output_line=on_output_line,
+            capture_result_text=True,
+            capture_stdout=False,
+        )
+
+    def test_execute_agent_passes_capture_result_text_to_blocking_helper(
+        self, monkeypatch
+    ):
+        on_output_line = MagicMock()
+        fake_blocking = MagicMock(return_value=AgentResult(returncode=0, elapsed=0.01))
+
+        monkeypatch.setattr("ralphify._agent._supports_stream_json", lambda cmd: False)
+        monkeypatch.setattr("ralphify._agent._run_agent_blocking", fake_blocking)
+
+        execute_agent(
+            ["echo"],
+            "prompt",
+            timeout=None,
+            log_dir=None,
+            iteration=1,
+            on_output_line=on_output_line,
+            capture_result_text=True,
+        )
+
+        fake_blocking.assert_called_once_with(
+            ["echo"],
+            "prompt",
+            None,
+            None,
+            1,
+            on_output_line=on_output_line,
+            capture_result_text=True,
+            capture_stdout=False,
+        )
+
 
 class TestExecuteAgentStreaming:
     """Tests for the streaming execution path (_run_agent_streaming)."""
+
+    @patch(MOCK_SUBPROCESS)
+    def test_streaming_result_event_populates_result_text(self, mock_popen):
+        mock_popen.return_value = make_mock_popen(
+            stdout_lines='{"type": "result", "result": "early done"}\n',
+            returncode=0,
+        )
+        result = _run_agent_streaming(
+            ["claude", "-p"],
+            "prompt",
+            timeout=10,
+            log_dir=None,
+            iteration=1,
+        )
+        assert result.result_text == "early done"
+        assert result.returncode == 0
+        assert result.timed_out is False
+
+    @patch(MOCK_SUBPROCESS)
+    def test_blocking_result_event_populates_result_text_when_captured(
+        self, mock_popen, tmp_path
+    ):
+        mock_popen.return_value = make_mock_popen(
+            stdout_lines='{"type": "result", "result": "early done"}\n',
+            returncode=0,
+        )
+        result = _run_agent_blocking(
+            ["claude", "-p"],
+            "prompt",
+            timeout=10,
+            log_dir=tmp_path,
+            iteration=1,
+        )
+
+        assert result.result_text == "early done"
+        assert result.returncode == 0
+        assert result.timed_out is False
+
+    @patch(MOCK_SUBPROCESS)
+    def test_result_text_absent_when_no_result_event(self, mock_popen):
+        mock_popen.return_value = make_mock_popen(
+            stdout_lines="status: working\n",
+            returncode=0,
+        )
+        result = _run_agent_streaming(
+            ["claude", "-p"],
+            "prompt",
+            timeout=10,
+            log_dir=None,
+            iteration=1,
+        )
+        assert result.result_text is None
+        assert result.returncode == 0
+        assert result.timed_out is False
+
+    @patch(MOCK_SUBPROCESS)
+    def test_last_result_event_wins(self, mock_popen):
+        mock_popen.return_value = make_mock_popen(
+            stdout_lines='{"type": "result", "result": "first"}\n{"type": "result", "result": "second"}\n',
+            returncode=0,
+        )
+        result = _run_agent_streaming(
+            ["claude", "-p"],
+            "prompt",
+            timeout=10,
+            log_dir=None,
+            iteration=1,
+        )
+        assert result.result_text == "second"
+        assert result.returncode == 0
+        assert result.timed_out is False
 
     @patch(MOCK_SUBPROCESS)
     def test_success(self, mock_popen):
@@ -565,6 +728,41 @@ class TestExecuteAgentStreaming:
 
         assert result.captured_stdout == "agent output\n"
         assert result.captured_stderr == "some stderr\n"
+
+    @patch(MOCK_SUBPROCESS)
+    def test_capture_result_text_does_not_buffer_stream_output_without_log_dir(
+        self, mock_popen
+    ):
+        mock_popen.return_value = make_mock_popen(
+            stdout_lines="<promise>done</promise>\n",
+            stderr_text="some stderr\n",
+            returncode=0,
+        )
+        result = _run_agent_streaming(
+            ["claude", "-p"],
+            "prompt",
+            timeout=None,
+            log_dir=None,
+            iteration=1,
+            capture_result_text=True,
+        )
+
+        assert result.captured_stdout is None
+        assert result.captured_stderr is None
+        assert result.result_text is None
+
+        call_args = mock_popen.call_args
+        assert call_args.args[0] == [
+            "claude",
+            "-p",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+        ]
+        call_kwargs = call_args[1]
+        assert call_kwargs.get("stdin") == subprocess.PIPE
+        assert call_kwargs.get("stdout") == subprocess.PIPE
+        assert call_kwargs.get("stderr") is None
 
     @patch(MOCK_SUBPROCESS)
     def test_no_log_when_dir_not_set(self, mock_popen):

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -19,35 +19,11 @@ from ralphify._agent import (
     _read_agent_stream,
     _run_agent_blocking,
     _run_agent_streaming,
-    _supports_stream_json,
     _write_log,
     execute_agent,
 )
-
-
-class TestSupportsStreamJson:
-    def test_claude_binary(self):
-        assert _supports_stream_json(["claude", "-p"]) is True
-
-    def test_claude_absolute_path(self):
-        assert _supports_stream_json(["/usr/local/bin/claude", "-p"]) is True
-
-    def test_non_claude_binary(self):
-        assert _supports_stream_json(["aider", "--yes"]) is False
-
-    def test_empty_command(self):
-        assert _supports_stream_json([]) is False
-
-    def test_claude_like_name(self):
-        assert _supports_stream_json(["claude-code"]) is False
-
-    def test_claude_with_cmd_extension(self):
-        """On Windows, npm installs claude as claude.cmd — streaming must
-        still be detected."""
-        assert _supports_stream_json(["claude.cmd", "-p"]) is True
-
-    def test_claude_with_exe_extension(self):
-        assert _supports_stream_json(["claude.exe", "-p"]) is True
+from ralphify.adapters import select_adapter
+from ralphify.adapters.claude import ClaudeAdapter
 
 
 class TestWriteLog:
@@ -449,8 +425,11 @@ class TestExecuteAgentDispatch:
 
     @patch(MOCK_SUBPROCESS)
     def test_dispatches_to_streaming_for_claude(self, mock_popen, monkeypatch):
-        """execute_agent uses the streaming path when the agent supports it."""
-        monkeypatch.setattr("ralphify._agent._supports_stream_json", lambda cmd: True)
+        """execute_agent uses the streaming path when the adapter renders
+        structured output."""
+        claude_adapter = select_adapter(["claude"])
+        assert isinstance(claude_adapter, ClaudeAdapter)
+        monkeypatch.setattr(claude_adapter, "supports_streaming", True)
         mock_popen.return_value = make_mock_popen(
             stdout_lines='{"type": "result", "result": "done"}\n',
             returncode=0,
@@ -474,7 +453,9 @@ class TestExecuteAgentDispatch:
         on_output_line = MagicMock()
         fake_streaming = MagicMock(return_value=AgentResult(returncode=0, elapsed=0.01))
 
-        monkeypatch.setattr("ralphify._agent._supports_stream_json", lambda cmd: True)
+        claude_adapter = select_adapter(["claude"])
+        assert isinstance(claude_adapter, ClaudeAdapter)
+        monkeypatch.setattr(claude_adapter, "supports_streaming", True)
         monkeypatch.setattr("ralphify._agent._run_agent_streaming", fake_streaming)
 
         execute_agent(
@@ -489,7 +470,7 @@ class TestExecuteAgentDispatch:
         )
 
         fake_streaming.assert_called_once_with(
-            ["claude", "-p"],
+            claude_adapter.build_command(["claude", "-p"]),
             "prompt",
             None,
             None,
@@ -506,7 +487,9 @@ class TestExecuteAgentDispatch:
         on_output_line = MagicMock()
         fake_blocking = MagicMock(return_value=AgentResult(returncode=0, elapsed=0.01))
 
-        monkeypatch.setattr("ralphify._agent._supports_stream_json", lambda cmd: False)
+        # The autouse conftest fixture already forces every adapter's
+        # supports_streaming flag to False, so ``echo`` falls into the
+        # blocking path through the GenericAdapter fallback.
         monkeypatch.setattr("ralphify._agent._run_agent_blocking", fake_blocking)
 
         execute_agent(
@@ -670,10 +653,12 @@ class TestExecuteAgentStreaming:
         proc.stdin.close.assert_called_once()
 
     @patch(MOCK_SUBPROCESS)
-    def test_adds_stream_json_flags(self, mock_popen):
+    def test_passes_cmd_verbatim_to_popen(self, mock_popen):
+        """_run_agent_streaming no longer appends its own flags — the caller
+        (via ``adapter.build_command``) owns CLI flags now."""
         mock_popen.return_value = make_mock_popen(returncode=0)
         _run_agent_streaming(
-            ["claude", "-p"],
+            ["claude", "-p", "--output-format", "stream-json", "--verbose"],
             "prompt",
             timeout=None,
             log_dir=None,
@@ -682,9 +667,13 @@ class TestExecuteAgentStreaming:
 
         call_args = mock_popen.call_args
         cmd = call_args[0][0]
-        assert "--output-format" in cmd
-        assert "stream-json" in cmd
-        assert "--verbose" in cmd
+        assert cmd == [
+            "claude",
+            "-p",
+            "--output-format",
+            "stream-json",
+            "--verbose",
+        ]
 
     @patch(MOCK_SUBPROCESS)
     def test_writes_log_on_success(self, mock_popen, tmp_path):
@@ -752,13 +741,7 @@ class TestExecuteAgentStreaming:
         assert result.result_text is None
 
         call_args = mock_popen.call_args
-        assert call_args.args[0] == [
-            "claude",
-            "-p",
-            "--output-format",
-            "stream-json",
-            "--verbose",
-        ]
+        assert call_args.args[0] == ["claude", "-p"]
         call_kwargs = call_args[1]
         assert call_kwargs.get("stdin") == subprocess.PIPE
         assert call_kwargs.get("stdout") == subprocess.PIPE

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 """Tests for the CLI."""
 
 import importlib
+import re
 import signal
 from unittest.mock import patch, MagicMock
 
@@ -22,6 +23,31 @@ from ralphify._frontmatter import RALPH_MARKER
 from ralphify.cli import app, _parse_command_items, _parse_user_args
 
 runner = CliRunner()
+
+
+def _flatten_help(output: str) -> str:
+    no_ansi = re.sub(r"\x1b\[[0-9;]*[a-zA-Z]", "", output)
+    return re.sub(r"\s+", " ", no_ansi)
+
+
+class TestHelp:
+    def test_scaffold_help_mentions_promise_completion(self):
+        result = runner.invoke(app, ["scaffold", "--help"])
+
+        assert result.exit_code == 0
+        flat = _flatten_help(result.output)
+        assert "completion_signal" in flat
+        assert "stop_on_completion_signal" in flat
+        assert "<promise>...</promise>" in flat
+
+    def test_run_help_mentions_promise_completion(self):
+        result = runner.invoke(app, ["run", "--help"])
+
+        assert result.exit_code == 0
+        flat = _flatten_help(result.output)
+        assert "completion_signal" in flat
+        assert "stop_on_completion_signal" in flat
+        assert "<promise>...</promise>" in flat
 
 
 class TestVersion:
@@ -94,6 +120,103 @@ class TestRun:
         result = runner.invoke(app, ["run", str(ralph_dir), "-n", "1"])
         assert result.exit_code == 1
         assert "malformed" in result.output.lower()
+
+    def test_run_uses_default_completion_signal_config(
+        self, mock_which, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        ralph_dir = make_ralph(tmp_path)
+        with patch("ralphify.cli.run_loop") as mock_run_loop:
+            result = runner.invoke(app, ["run", str(ralph_dir), "-n", "3"])
+
+        assert result.exit_code == 0
+        mock_run_loop.assert_called_once()
+        config = mock_run_loop.call_args.args[0]
+        assert config.completion_signal == "RALPH_PROMISE_COMPLETE"
+        assert config.stop_on_completion_signal is False
+        assert config.max_iterations == 3
+
+    def test_run_passes_completion_signal_frontmatter_to_config(
+        self, mock_which, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        ralph_dir = tmp_path / "my-ralph"
+        ralph_dir.mkdir()
+        (ralph_dir / RALPH_MARKER).write_text(
+            "---\n"
+            "agent: claude -p --dangerously-skip-permissions\n"
+            "completion_signal: CUSTOM_DONE\n"
+            "stop_on_completion_signal: true\n"
+            "---\n"
+            "go"
+        )
+        with patch("ralphify.cli.run_loop") as mock_run_loop:
+            result = runner.invoke(app, ["run", str(ralph_dir), "-n", "2"])
+
+        assert result.exit_code == 0
+        mock_run_loop.assert_called_once()
+        config = mock_run_loop.call_args.args[0]
+        assert config.completion_signal == "CUSTOM_DONE"
+        assert config.stop_on_completion_signal is True
+
+    @pytest.mark.parametrize(
+        ("frontmatter_line", "expected_error"),
+        [
+            ("completion_signal: 0", "must be a non-empty string"),
+            (
+                'completion_signal: " CUSTOM_DONE "',
+                "must not include leading or trailing whitespace",
+            ),
+            (
+                'completion_signal: "<promise>CUSTOM_DONE</promise>"',
+                "must be the text inside <promise>...</promise>",
+            ),
+        ],
+        ids=["wrong-type", "surrounding-whitespace", "markup-instead-of-text"],
+    )
+    def test_run_rejects_invalid_completion_signal_frontmatter(
+        self, mock_which, tmp_path, monkeypatch, frontmatter_line, expected_error
+    ):
+        monkeypatch.chdir(tmp_path)
+        ralph_dir = tmp_path / "my-ralph"
+        ralph_dir.mkdir()
+        (ralph_dir / RALPH_MARKER).write_text(
+            "---\n"
+            "agent: claude -p --dangerously-skip-permissions\n"
+            f"{frontmatter_line}\n"
+            "---\n"
+            "go"
+        )
+
+        with patch("ralphify.cli.run_loop") as mock_run_loop:
+            result = runner.invoke(app, ["run", str(ralph_dir), "-n", "1"])
+
+        assert result.exit_code == 1
+        assert "completion_signal" in result.output.lower()
+        assert expected_error in result.output.lower()
+        mock_run_loop.assert_not_called()
+
+    def test_run_rejects_non_boolean_stop_on_completion_signal(
+        self, mock_which, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)
+        ralph_dir = tmp_path / "my-ralph"
+        ralph_dir.mkdir()
+        (ralph_dir / RALPH_MARKER).write_text(
+            "---\n"
+            "agent: claude -p --dangerously-skip-permissions\n"
+            'stop_on_completion_signal: "maybe"\n'
+            "---\n"
+            "go"
+        )
+
+        with patch("ralphify.cli.run_loop") as mock_run_loop:
+            result = runner.invoke(app, ["run", str(ralph_dir), "-n", "1"])
+
+        assert result.exit_code == 1
+        assert "stop_on_completion_signal" in result.output.lower()
+        assert "must be true or false" in result.output.lower()
+        mock_run_loop.assert_not_called()
 
     @pytest.mark.parametrize(
         "frontmatter, expected_error",
@@ -517,6 +640,16 @@ class TestScaffold:
         assert ralph_file.exists()
         assert "Created" in result.output
 
+    def test_scaffold_output_mentions_promise_completion(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        result = runner.invoke(app, ["scaffold", "my-task"])
+
+        assert result.exit_code == 0
+        assert "completion_signal" in result.output
+        assert "stop_on_completion_signal" in result.output
+        assert "<promise>COMPLETE</promise>" in result.output
+
     def test_creates_ralph_in_cwd(self, tmp_path, monkeypatch):
         monkeypatch.chdir(tmp_path)
         result = runner.invoke(app, ["scaffold"])
@@ -555,6 +688,16 @@ class TestScaffold:
         assert isinstance(fm["args"], list)
         assert "{{ commands.git-log }}" in body
         assert "{{ args.focus }}" in body
+
+    def test_template_mentions_promise_completion_path(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+
+        runner.invoke(app, ["scaffold", "my-task"])
+        content = (tmp_path / "my-task" / RALPH_MARKER).read_text()
+
+        assert "# completion_signal: COMPLETE" in content
+        assert "# stop_on_completion_signal: true" in content
+        assert "<promise>COMPLETE</promise>" in content
 
 
 class TestParseUserArgs:

--- a/tests/test_console_emitter.py
+++ b/tests/test_console_emitter.py
@@ -15,9 +15,9 @@ from ralphify._console_emitter import (
     _IterationPanel,
     _IterationSpinner,
     _SinglePanelNavigator,
+    _agent_renders_structured_peek,
     _format_run_info,
     _format_summary,
-    _is_claude_command,
     _scrollbar_metrics,
     _shorten_path,
 )
@@ -332,7 +332,11 @@ class TestPeekToggle:
         output = console.export_text()
         assert "press p to hide" in output
 
-    def test_startup_hint_structured_for_claude(self):
+    def test_startup_hint_structured_for_claude(self, monkeypatch):
+        from ralphify.adapters import select_adapter
+
+        claude_adapter = select_adapter(["claude"])
+        monkeypatch.setattr(claude_adapter, "renders_structured_peek", True)
         emitter, console = _capture_emitter()
         emitter._peek_enabled = True
         emitter.emit(
@@ -1499,24 +1503,33 @@ class TestIterationSpinnerScrollLines:
         assert "live output on" in output
 
 
-class TestIsClaudeCommand:
-    def test_claude_binary(self):
-        assert _is_claude_command("claude") is True
+class TestAgentRendersStructuredPeek:
+    """Verify the emitter routes through :func:`select_adapter`."""
 
-    def test_claude_with_flags(self):
-        assert _is_claude_command("claude --dangerously-skip-permissions") is True
+    def test_claude_adapter_reports_structured_peek(self, monkeypatch):
+        from ralphify.adapters import select_adapter
+        from ralphify.adapters.claude import ClaudeAdapter
 
-    def test_claude_full_path(self):
-        assert _is_claude_command("/usr/local/bin/claude -p") is True
+        adapter = select_adapter(["claude"])
+        assert isinstance(adapter, ClaudeAdapter)
+        monkeypatch.setattr(adapter, "renders_structured_peek", True)
+        assert _agent_renders_structured_peek("claude") is True
+        assert (
+            _agent_renders_structured_peek("claude --dangerously-skip-permissions")
+            is True
+        )
+        assert _agent_renders_structured_peek("/usr/local/bin/claude -p") is True
 
-    def test_not_claude(self):
-        assert _is_claude_command("aider --yes") is False
+    def test_unknown_agent_falls_back_to_generic(self):
+        # conftest forces every adapter's renders_structured_peek to False;
+        # the GenericAdapter fallback also reports False.
+        assert _agent_renders_structured_peek("aider --yes") is False
 
-    def test_empty(self):
-        assert _is_claude_command("") is False
+    def test_empty_string_is_not_structured(self):
+        assert _agent_renders_structured_peek("") is False
 
-    def test_invalid_shlex(self):
-        assert _is_claude_command("claude 'unterminated") is False
+    def test_invalid_shlex_is_not_structured(self):
+        assert _agent_renders_structured_peek("claude 'unterminated") is False
 
 
 def _populate_buffer(spinner, count: int, prefix: str = "line") -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -132,13 +132,21 @@ class TestPromiseCompletionSignals:
     def test_tagged_promise_does_not_stop_by_default(
         self, mock_execute_agent, tmp_path
     ):
+        """Without ``stop_on_completion_signal`` the loop must run all iterations.
+
+        A non-streaming adapter (here ``echo`` → GenericAdapter) only sees
+        promise completion when the engine elects to capture stdout, which
+        in turn requires either logging or the explicit opt-in.  Skipping
+        the buffer is the whole point of the gating, so
+        ``state.promise_completed`` legitimately stays False here.
+        """
         config = make_config(tmp_path, max_iterations=3)
         state = make_state()
         emitter = NullEmitter()
         mock_execute_agent.return_value = AgentResult(
             returncode=0,
             elapsed=0.01,
-            captured_stdout="<promise>RALPH_PROMISE_COMPLETE</promise>\n",
+            captured_stdout=None,
         )
 
         run_loop(config, state, emitter)
@@ -147,7 +155,7 @@ class TestPromiseCompletionSignals:
         assert state.completed == 3
         assert state.failed == 0
         assert state.status == RunStatus.COMPLETED
-        assert state.promise_completed is True
+        assert state.promise_completed is False
         assert [
             call.kwargs["on_output_line"] for call in mock_execute_agent.call_args_list
         ] == [None, None, None]
@@ -155,6 +163,80 @@ class TestPromiseCompletionSignals:
             call.kwargs["capture_result_text"]
             for call in mock_execute_agent.call_args_list
         ] == [True, True, True]
+        # Generic adapter requires full stdout, but the user didn't opt in
+        # and no log dir is set — capture should stay off to avoid
+        # buffering verbose agent output.
+        assert [
+            call.kwargs["capture_stdout"] for call in mock_execute_agent.call_args_list
+        ] == [False, False, False]
+
+    @patch("ralphify.engine.execute_agent")
+    def test_capture_stdout_off_for_streaming_adapter_without_logging(
+        self, mock_execute_agent, tmp_path
+    ):
+        """Claude exposes ``result_text`` directly; the engine must not
+        force-buffer the full stdout transcript even when the user opts
+        into ``stop_on_completion_signal``."""
+        config = make_config(
+            tmp_path,
+            agent="claude",
+            max_iterations=1,
+            stop_on_completion_signal=True,
+        )
+        state = make_state()
+
+        mock_execute_agent.return_value = AgentResult(
+            returncode=0,
+            elapsed=0.01,
+            result_text="<promise>RALPH_PROMISE_COMPLETE</promise>",
+        )
+
+        run_loop(config, state, NullEmitter())
+
+        assert mock_execute_agent.call_args.kwargs["capture_stdout"] is False
+        assert state.promise_completed is True
+
+    @patch("ralphify.engine.execute_agent")
+    def test_capture_stdout_on_for_blocking_adapter_with_opt_in(
+        self, mock_execute_agent, tmp_path
+    ):
+        """Generic / Copilot adapters need the full stdout buffer to
+        scan for the promise tag — engine must opt in when the user
+        opts into completion signalling."""
+        config = make_config(
+            tmp_path,
+            max_iterations=1,
+            stop_on_completion_signal=True,
+        )
+        state = make_state()
+
+        mock_execute_agent.return_value = AgentResult(
+            returncode=0,
+            elapsed=0.01,
+            captured_stdout="<promise>RALPH_PROMISE_COMPLETE</promise>\n",
+        )
+
+        run_loop(config, state, NullEmitter())
+
+        assert mock_execute_agent.call_args.kwargs["capture_stdout"] is True
+        assert state.promise_completed is True
+
+    @patch("ralphify.engine.execute_agent")
+    def test_capture_stdout_on_when_log_dir_set(self, mock_execute_agent, tmp_path):
+        """Logging always needs the buffer regardless of completion signal."""
+        log_dir = tmp_path / "logs"
+        config = make_config(tmp_path, max_iterations=1, log_dir=log_dir)
+        state = make_state()
+
+        mock_execute_agent.return_value = AgentResult(
+            returncode=0,
+            elapsed=0.01,
+            captured_stdout="anything\n",
+        )
+
+        run_loop(config, state, NullEmitter())
+
+        assert mock_execute_agent.call_args.kwargs["capture_stdout"] is True
 
     @patch("ralphify.engine.execute_agent")
     def test_tagged_promise_stops_early_when_enabled(
@@ -171,7 +253,7 @@ class TestPromiseCompletionSignals:
         mock_execute_agent.return_value = AgentResult(
             returncode=0,
             elapsed=0.01,
-            result_text="<promise>RALPH_PROMISE_COMPLETE</promise>",
+            captured_stdout="<promise>RALPH_PROMISE_COMPLETE</promise>\n",
         )
 
         run_loop(config, state, emitter)
@@ -210,7 +292,7 @@ class TestPromiseCompletionSignals:
         mock_execute_agent.return_value = AgentResult(
             returncode=0,
             elapsed=0.01,
-            result_text="<promise>CUSTOM_DONE</promise>",
+            captured_stdout="<promise>CUSTOM_DONE</promise>\n",
         )
 
         run_loop(config, state, emitter)
@@ -243,7 +325,7 @@ class TestPromiseCompletionSignals:
         mock_execute_agent.return_value = AgentResult(
             returncode=0,
             elapsed=0.01,
-            result_text="<promise>\n  CUSTOM\tDONE  \n</promise>",
+            captured_stdout="<promise>\n  CUSTOM\tDONE  \n</promise>\n",
         )
 
         run_loop(config, state, NullEmitter())
@@ -311,8 +393,12 @@ class TestPromiseCompletionSignals:
     def test_structured_agents_ignore_raw_stdout_for_promise_detection(
         self, mock_execute_agent, tmp_path
     ):
+        """ClaudeAdapter only looks at ``result`` events — embedded
+        promise tags inside ``status`` or ``assistant`` JSON messages
+        must not trigger early completion."""
         config = make_config(
             tmp_path,
+            agent="claude",
             max_iterations=2,
             stop_on_completion_signal=True,
         )

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -20,6 +20,7 @@ from helpers import (
 )
 from rich.console import Console
 
+from ralphify._agent import AgentResult
 from ralphify._console_emitter import ConsoleEmitter
 from ralphify._events import BoundEmitter, EventType, NullEmitter, QueueEmitter
 from ralphify._run_types import Command, RunStatus
@@ -124,6 +125,234 @@ class TestRunLoop:
         assert len(log_files) == 2
         assert log_files[0].name.startswith("001_")
         assert log_files[1].name.startswith("002_")
+
+
+class TestPromiseCompletionSignals:
+    @patch("ralphify.engine.execute_agent")
+    def test_tagged_promise_does_not_stop_by_default(
+        self, mock_execute_agent, tmp_path
+    ):
+        config = make_config(tmp_path, max_iterations=3)
+        state = make_state()
+        emitter = NullEmitter()
+        mock_execute_agent.return_value = AgentResult(
+            returncode=0,
+            elapsed=0.01,
+            captured_stdout="<promise>RALPH_PROMISE_COMPLETE</promise>\n",
+        )
+
+        run_loop(config, state, emitter)
+
+        assert mock_execute_agent.call_count == 3
+        assert state.completed == 3
+        assert state.failed == 0
+        assert state.status == RunStatus.COMPLETED
+        assert state.promise_completed is True
+        assert [
+            call.kwargs["on_output_line"] for call in mock_execute_agent.call_args_list
+        ] == [None, None, None]
+        assert [
+            call.kwargs["capture_result_text"]
+            for call in mock_execute_agent.call_args_list
+        ] == [True, True, True]
+
+    @patch("ralphify.engine.execute_agent")
+    def test_tagged_promise_stops_early_when_enabled(
+        self, mock_execute_agent, tmp_path
+    ):
+        config = make_config(
+            tmp_path,
+            max_iterations=5,
+            stop_on_completion_signal=True,
+        )
+        state = make_state()
+        emitter = QueueEmitter()
+        emitter.wants_agent_output_lines = lambda: True
+        mock_execute_agent.return_value = AgentResult(
+            returncode=0,
+            elapsed=0.01,
+            result_text="<promise>RALPH_PROMISE_COMPLETE</promise>",
+        )
+
+        run_loop(config, state, emitter)
+
+        mock_execute_agent.assert_called_once()
+        assert mock_execute_agent.call_args.kwargs["capture_result_text"] is True
+        assert state.iteration == 1
+        assert state.completed == 1
+        assert state.failed == 0
+        assert state.total == 1
+        assert state.status == RunStatus.COMPLETED
+        assert state.promise_completed is True
+
+        events = drain_events(emitter)
+        completed_events = events_of_type(events, EventType.ITERATION_COMPLETED)
+        assert len(completed_events) == 1
+        stop_event = events_of_type(events, EventType.RUN_STOPPED)[0]
+        assert stop_event.data["reason"] == "completed"
+        assert stop_event.data["total"] == 1
+        assert stop_event.data["completed"] == 1
+        assert stop_event.data["failed"] == 0
+        assert stop_event.data["timed_out_count"] == 0
+
+    @patch("ralphify.engine.execute_agent")
+    def test_custom_promise_text_matches_inner_tag_text(
+        self, mock_execute_agent, tmp_path
+    ):
+        config = make_config(
+            tmp_path,
+            max_iterations=4,
+            completion_signal="CUSTOM_DONE",
+            stop_on_completion_signal=True,
+        )
+        state = make_state()
+        emitter = QueueEmitter()
+        mock_execute_agent.return_value = AgentResult(
+            returncode=0,
+            elapsed=0.01,
+            result_text="<promise>CUSTOM_DONE</promise>",
+        )
+
+        run_loop(config, state, emitter)
+
+        mock_execute_agent.assert_called_once()
+        assert state.iteration == 1
+        assert state.completed == 1
+        assert state.failed == 0
+        assert state.status == RunStatus.COMPLETED
+        assert state.promise_completed is True
+
+        events = drain_events(emitter)
+        stop_event = events_of_type(events, EventType.RUN_STOPPED)[0]
+        assert stop_event.data["reason"] == "completed"
+        assert stop_event.data["total"] == 1
+        assert stop_event.data["completed"] == 1
+
+    @patch("ralphify.engine.execute_agent")
+    def test_promise_tag_normalizes_inner_whitespace_before_matching(
+        self, mock_execute_agent, tmp_path
+    ):
+        config = make_config(
+            tmp_path,
+            max_iterations=4,
+            completion_signal="CUSTOM DONE",
+            stop_on_completion_signal=True,
+        )
+        state = make_state()
+
+        mock_execute_agent.return_value = AgentResult(
+            returncode=0,
+            elapsed=0.01,
+            result_text="<promise>\n  CUSTOM\tDONE  \n</promise>",
+        )
+
+        run_loop(config, state, NullEmitter())
+
+        assert mock_execute_agent.call_count == 1
+        assert state.iteration == 1
+        assert state.completed == 1
+        assert state.failed == 0
+        assert state.total == 1
+        assert state.status == RunStatus.COMPLETED
+        assert state.promise_completed is True
+
+    @patch("ralphify.engine.execute_agent")
+    def test_untagged_raw_text_does_not_match_completion_signal(
+        self, mock_execute_agent, tmp_path
+    ):
+        config = make_config(
+            tmp_path,
+            max_iterations=3,
+            stop_on_completion_signal=True,
+        )
+        state = make_state()
+
+        mock_execute_agent.return_value = AgentResult(
+            returncode=0,
+            elapsed=0.01,
+            result_text="done RALPH_PROMISE_COMPLETE without promise tags",
+        )
+
+        run_loop(config, state, NullEmitter())
+
+        assert mock_execute_agent.call_count == 3
+        assert state.completed == 3
+        assert state.failed == 0
+        assert state.status == RunStatus.COMPLETED
+        assert state.promise_completed is False
+
+    @patch("ralphify.engine.execute_agent")
+    def test_different_tagged_promise_text_does_not_match(
+        self, mock_execute_agent, tmp_path
+    ):
+        config = make_config(
+            tmp_path,
+            max_iterations=3,
+            completion_signal="CUSTOM_DONE",
+            stop_on_completion_signal=True,
+        )
+        state = make_state()
+
+        mock_execute_agent.return_value = AgentResult(
+            returncode=0,
+            elapsed=0.01,
+            result_text="<promise>CUSTOM_DONE_NOW</promise>",
+        )
+
+        run_loop(config, state, NullEmitter())
+
+        assert mock_execute_agent.call_count == 3
+        assert state.completed == 3
+        assert state.failed == 0
+        assert state.status == RunStatus.COMPLETED
+        assert state.promise_completed is False
+
+    @patch("ralphify.engine.execute_agent")
+    def test_structured_agents_ignore_raw_stdout_for_promise_detection(
+        self, mock_execute_agent, tmp_path
+    ):
+        config = make_config(
+            tmp_path,
+            max_iterations=2,
+            stop_on_completion_signal=True,
+        )
+        state = make_state()
+
+        mock_execute_agent.return_value = AgentResult(
+            returncode=0,
+            elapsed=0.01,
+            result_text="done without promise tag",
+            captured_stdout='{"type":"status","message":"<promise>RALPH_PROMISE_COMPLETE</promise>"}\n',
+        )
+
+        run_loop(config, state, NullEmitter())
+
+        assert mock_execute_agent.call_count == 2
+        assert state.completed == 2
+        assert state.failed == 0
+        assert state.status == RunStatus.COMPLETED
+        assert state.promise_completed is False
+
+    @patch("ralphify.engine.execute_agent")
+    def test_blocking_captured_stdout_is_echoed_when_peek_is_off(
+        self, mock_execute_agent, tmp_path
+    ):
+        config = make_config(tmp_path, max_iterations=1)
+        state = make_state()
+        emitter = QueueEmitter()
+
+        mock_execute_agent.return_value = AgentResult(
+            returncode=0,
+            elapsed=0.01,
+            captured_stdout="plain blocking output\n",
+        )
+
+        run_loop(config, state, emitter)
+
+        completed_event = events_of_type(
+            drain_events(emitter), EventType.ITERATION_COMPLETED
+        )[0]
+        assert completed_event.data["echo_stdout"] == "plain blocking output\n"
 
 
 class TestRunLoopDefaults:

--- a/tests/test_promise.py
+++ b/tests/test_promise.py
@@ -1,0 +1,47 @@
+"""Tests for strict promise-tag parsing."""
+
+import pytest
+
+from ralphify._promise import has_promise_completion, parse_promise_tags
+
+
+class TestParsePromiseTags:
+    @pytest.mark.parametrize(
+        "raw_text", [None, "", "plain text", "<promise>missing close"]
+    )
+    def test_parse_promise_tags_invalid_input_returns_empty_list(self, raw_text):
+        assert parse_promise_tags(raw_text) == []
+
+    def test_parse_promise_tags_normalizes_whitespace_and_preserves_unicode(self):
+        text = (
+            "before "
+            "<promise>\n  CUSTOM\tDONE  \n</promise> "
+            "middle "
+            "<promise>✅ shipped</promise>"
+        )
+
+        assert parse_promise_tags(text) == ["CUSTOM DONE", "✅ shipped"]
+
+
+class TestHasPromiseCompletion:
+    def test_has_promise_completion_matches_only_exact_tag_payload(self):
+        text = (
+            "raw CUSTOM_DONE text "
+            "<promise>CUSTOM_DONE_NOW</promise> "
+            "<promise>CUSTOM_DONE</promise>"
+        )
+
+        assert has_promise_completion(text, "CUSTOM_DONE") is True
+        assert has_promise_completion(text, "CUSTOM_DONE_NOW") is True
+        assert has_promise_completion(text, "CUSTOM") is False
+
+    def test_has_promise_completion_ignores_wrong_case_and_malformed_tags(self):
+        text = "<PROMISE>CUSTOM_DONE</PROMISE><promise>CUSTOM_DONE</promise-ish>"
+
+        assert has_promise_completion(text, "CUSTOM_DONE") is False
+
+    def test_has_promise_completion_normalizes_completion_signal_whitespace(self):
+        text = "<promise>\n  CUSTOM\tDONE  \n</promise>"
+
+        assert has_promise_completion(text, "CUSTOM DONE") is True
+        assert has_promise_completion(text, "CUSTOM\tDONE") is True


### PR DESCRIPTION
## Summary

Adds a prompt-cache observability primitive to the CLI adapter layer (PR #6 follow-up). No engine or UI wiring yet — this is the adapter-side shape so future callers have something uniform to consume.

## Context

Research on prompt-cache support per CLI:

| CLI | Cache? | Observable |
|-----|--------|------------|
| Claude | Auto-injects `cache_control: ephemeral` on system prompt / CLAUDE.md / tool defs. 5-min TTL. | Yes — `message.usage.cache_read_input_tokens` / `cache_creation_input_tokens` on every event. |
| Codex | Responses API auto-caches. ~5–10 min idle TTL. Routing stickiness *not* guaranteed across fresh `codex exec` — hits are probabilistic. | Yes — `usage.input_tokens_details.cached_tokens`. |
| Copilot | Unknown, no public knobs. | No verified schema. |

"Passed to the CLI" ≠ "cached." The CLI is transport; caching is a server-side concern with TTLs and routing constraints the CLI can't force. The honest path is to **observe** whether caching happened rather than flip a flag claiming it.

## What this PR adds

- `CacheStats` NamedTuple: `read_tokens` / `write_tokens` / `uncached_tokens`. Total input = sum; hit rate = `read / total`. `write_tokens` is Claude-only (OpenAI doesn't distinguish writes from misses, so Codex reports `0`).
- `supports_prompt_caching: bool` attribute on every adapter. Signals "this CLI has an observable caching story at all."
- `extract_cache_stats(raw) -> CacheStats | None` method on every adapter. Called per parsed event; `None` means "no usage payload on this event" (distinct from a capable adapter observing zero hits).

Per-adapter:

- **ClaudeAdapter**: `supports_prompt_caching=True`. Parses `message.usage` (assistant) and top-level `usage` (result).
- **CodexAdapter**: `supports_prompt_caching=True`. Parses Responses API (`input_tokens_details.cached_tokens`) with fallback to legacy Chat shape (`prompt_tokens_details.cached_tokens`). Nested `msg.usage` supported.
- **CopilotAdapter**: `supports_prompt_caching=False`. Always `None`.
- **GenericAdapter**: `supports_prompt_caching=False`. Always `None`.

## Scope excluded (deliberate)

- **No engine wiring.** The console emitter does not yet surface stats; nothing reads `extract_cache_stats` in the run loop.
- **No session-level aggregation.** Per-event stats only; a rollup ("this run: 82% cache hit rate") is a follow-up.
- **No `codex resume <thread-id>` support.** That would change the ralph "fresh context per iteration" model and is a separate design conversation.
- **No TTL extension.** `prompt_cache_retention` for Codex is not surfaced in the `codex` CLI today.

## Test plan

- [x] 29 new adapter tests covering happy path, missing usage, malformed shapes, capability flags
- [x] `uv run pytest` → 722 passed, 1 xpassed
- [x] `uv run ruff check .` → clean
- [x] `uv run ruff format --check .` → clean
- [x] `uv run ty check` → clean
- [x] All four adapters pass the runtime `isinstance(adapter, CLIAdapter)` Protocol check (existing test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)