### PR TITLE
docs: clarify educational maintenance status

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
   <a href="https://ralphify.co/docs/"><img src="https://img.shields.io/badge/docs-ralphify.co%2Fdocs-blue" alt="Documentation"></a>
 </p>
 
+> [!IMPORTANT]
+> This repository is kept for educational purposes and is not actively
+> maintained. You are welcome to study and reuse the code, but should not expect
+> updates, support, or production-readiness.
+
 **Ralphify is the runtime for loop engineering.**
 
 *Loop engineering* — designing autonomous agent loops instead of prompting turn by turn — is becoming how people get real work out of coding agents. You write a loop once and let it drive the agent for hours, one commit at a time.

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,11 @@ hide:
   - toc
 ---
 
+!!! important
+    Ralphify is kept for educational purposes and is not actively maintained.
+    You are welcome to study and reuse the code, but should not expect updates,
+    support, or production-readiness.
+
 <p align="center">
   <img src="assets/cli-banner.png" alt="Ralphify CLI banner" style="max-width: 500px;" />
 </p>


### PR DESCRIPTION
## What changed

- add a prominent maintenance notice to the README
- add the same notice to the published docs home page

## Why

Ralphify is not actively maintained. The notice sets clear expectations and keeps the repository available as an educational resource.

## Impact

Visitors now see the project status before installation or adoption. The software itself is unchanged.

## Validation

- `uvx --with mkdocs-material --with mkdocs-git-revision-date-localized-plugin mkdocs build --strict`
- `git diff --check`